### PR TITLE
Add MySQL docker-compose and Prisma backend setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Connection string for the MySQL database used by the backend services
+DATABASE_URL="mysql://iroha:iroha_password@localhost:3306/iroha"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "iroha-backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:migrate:deploy": "prisma migrate deploy",
+    "prisma:studio": "prisma studio",
+    "db:seed": "ts-node prisma/seed.ts"
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.12.1"
+  },
+  "devDependencies": {
+    "prisma": "^5.12.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.3"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,11 @@
+// Prisma schema for the iroha backend.
+// Define your data models in this file.
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,15 @@
+/**
+ * Seed script placeholder.
+ *
+ * Use this file to populate the database with initial data.
+ * Run `npm run db:seed` from the backend directory after installing dependencies.
+ */
+
+async function main() {
+  console.info('Seed script not yet implemented.');
+}
+
+main().catch((error) => {
+  console.error('Seed script failed:', error);
+  process.exit(1);
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["prisma/**/*.ts"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+services:
+  mysql:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_DATABASE: iroha
+      MYSQL_USER: iroha
+      MYSQL_PASSWORD: iroha_password
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+volumes:
+  mysql_data:


### PR DESCRIPTION
## Summary
- add a docker-compose configuration for a local MySQL 8 instance used by iroha services
- provide a repository-wide .env example exposing the DATABASE_URL connection string
- scaffold the backend directory with Prisma tooling, migration scripts, and a seed placeholder

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d482020428832f90526e1651ac8d7b