### PR TITLE
feat: configure prisma schema and seeding

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,343 @@
+{
+  "name": "iroha-backend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "iroha-backend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@prisma/client": "^5.12.1"
+      },
+      "devDependencies": {
+        "prisma": "^5.12.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/fetch-engine": "5.22.0",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/prisma": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/engines": "5.22.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,11 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev",
-    "prisma:migrate:deploy": "prisma migrate deploy",
-    "prisma:studio": "prisma studio",
-    "db:seed": "ts-node prisma/seed.ts"
+    "db:generate": "prisma generate",
+    "db:migrate": "prisma migrate dev",
+    "db:seed": "ts-node prisma/seed.ts",
+    "db:studio": "prisma studio"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -9,3 +9,236 @@ datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
 }
+
+enum SeasonStatus {
+  scheduled
+  enrolling
+  running
+  complete
+  archived
+}
+
+enum CourseLevel {
+  A0
+  A1
+  A2
+  B1
+  B2
+}
+
+enum CourseModality {
+  live
+  recorded
+  hybrid
+}
+
+enum EnrollmentStatus {
+  pending
+  active
+  waitlisted
+  cancelled
+  completed
+}
+
+enum PaymentStatus {
+  initiated
+  paid
+  failed
+  refunded
+}
+
+model users {
+  id            BigInt         @id @default(autoincrement())
+  email         String         @unique @db.VarChar(255)
+  phone         String?        @db.VarChar(30)
+  password_hash String?        @db.VarChar(255)
+  first_name    String?        @db.VarChar(100)
+  last_name     String?        @db.VarChar(100)
+  locale        String         @default("ar") @db.VarChar(10)
+  timezone      String         @default("Asia/Riyadh") @db.VarChar(50)
+  created_at    DateTime       @default(now())
+
+  user_roles   user_roles[]
+  sections     sections[]      @relation("SectionInstructor")
+  enrollments  enrollments[]
+  quiz_attempts quiz_attempts[]
+  attendance   attendance[]
+}
+
+model roles {
+  id   Int     @id @db.TinyInt
+  name String  @unique @db.VarChar(50)
+
+  user_roles user_roles[]
+}
+
+model user_roles {
+  user_id BigInt
+  role_id Int     @db.TinyInt
+
+  user users @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  role roles @relation(fields: [role_id], references: [id], onDelete: Cascade)
+
+  @@id([user_id, role_id])
+}
+
+model seasons {
+  id               BigInt        @id @default(autoincrement())
+  code             String        @unique @db.VarChar(20)
+  title            String        @db.VarChar(100)
+  start_date       DateTime      @db.Date
+  end_date         DateTime      @db.Date
+  enrollment_open  DateTime
+  enrollment_close DateTime
+  status           SeasonStatus
+
+  courses courses[]
+}
+
+model courses {
+  id           BigInt          @id @default(autoincrement())
+  season_id    BigInt
+  code         String          @db.VarChar(50)
+  title        String          @db.VarChar(200)
+  level        CourseLevel
+  description  String?         @db.Text
+  modality     CourseModality  @default(hybrid)
+  language     String          @default("ja") @db.VarChar(10)
+  capacity     Int             @default(25)
+  price_cents  Int
+  currency     String          @default("SAR") @db.Char(3)
+  published    Boolean         @default(false)
+
+  season      seasons         @relation(fields: [season_id], references: [id], onDelete: Cascade)
+  sections    sections[]
+  lessons     lessons[]
+  enrollments enrollments[]
+  quizzes     quizzes[]
+
+  @@index([season_id])
+}
+
+model sections {
+  id             BigInt    @id @default(autoincrement())
+  course_id      BigInt
+  instructor_id  BigInt
+  title          String?   @db.VarChar(100)
+  meeting_link   String?   @db.VarChar(500)
+  weekday        Int       @db.TinyInt
+  start_time     DateTime  @db.Time
+  end_time       DateTime  @db.Time
+  start_date     DateTime  @db.Date
+  end_date       DateTime  @db.Date
+
+  course     courses   @relation(fields: [course_id], references: [id], onDelete: Cascade)
+  instructor users     @relation("SectionInstructor", fields: [instructor_id], references: [id])
+  lessons    lessons[]
+  enrollments enrollments[]
+  attendance attendance[]
+
+  @@index([course_id])
+  @@index([instructor_id])
+}
+
+model lessons {
+  id            BigInt    @id @default(autoincrement())
+  course_id     BigInt
+  section_id    BigInt?
+  week_no       Int?
+  title         String    @db.VarChar(200)
+  video_url     String?   @db.VarChar(500)
+  materials_json Json?
+  release_at    DateTime?
+
+  course   courses  @relation(fields: [course_id], references: [id], onDelete: Cascade)
+  section  sections? @relation(fields: [section_id], references: [id])
+}
+
+model enrollments {
+  id          BigInt           @id @default(autoincrement())
+  user_id     BigInt
+  course_id   BigInt
+  section_id  BigInt?
+  status      EnrollmentStatus
+  enrolled_at DateTime         @default(now())
+
+  user       users      @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  course     courses    @relation(fields: [course_id], references: [id], onDelete: Cascade)
+  section    sections?  @relation(fields: [section_id], references: [id])
+  payments   payments[]
+  certificate certificates?
+
+  @@unique([user_id, course_id])
+  @@index([course_id])
+  @@index([section_id])
+}
+
+model payments {
+  id            BigInt        @id @default(autoincrement())
+  enrollment_id BigInt
+  provider      String        @db.VarChar(50)
+  provider_ref  String        @db.VarChar(100)
+  amount_cents  Int
+  currency      String        @default("SAR") @db.Char(3)
+  status        PaymentStatus
+  created_at    DateTime      @default(now())
+
+  enrollment enrollments @relation(fields: [enrollment_id], references: [id], onDelete: Cascade)
+
+  @@index([enrollment_id])
+}
+
+model quizzes {
+  id             BigInt     @id @default(autoincrement())
+  course_id      BigInt
+  title          String     @db.VarChar(200)
+  total_points   Int
+  config_json    Json?
+  available_from DateTime?
+  due_at         DateTime?
+
+  course       courses       @relation(fields: [course_id], references: [id], onDelete: Cascade)
+  quiz_attempts quiz_attempts[]
+
+  @@index([course_id])
+}
+
+model quiz_attempts {
+  id           BigInt    @id @default(autoincrement())
+  quiz_id      BigInt
+  user_id      BigInt
+  score        Int?
+  submitted_at DateTime?
+  answers_json Json?
+
+  quiz quizzes @relation(fields: [quiz_id], references: [id], onDelete: Cascade)
+  user users   @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@index([quiz_id])
+  @@index([user_id])
+}
+
+model attendance {
+  id           BigInt    @id @default(autoincrement())
+  section_id   BigInt
+  user_id      BigInt
+  meeting_date DateTime  @db.Date
+  present      Boolean
+  note         String?   @db.VarChar(255)
+
+  section sections @relation(fields: [section_id], references: [id], onDelete: Cascade)
+  user    users    @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@unique([section_id, user_id, meeting_date])
+  @@index([user_id])
+}
+
+model certificates {
+  id            BigInt       @id @default(autoincrement())
+  enrollment_id BigInt       @unique
+  issued_at     DateTime?
+  pdf_url       String?      @db.VarChar(500)
+  grade         String?      @db.VarChar(10)
+
+  enrollment enrollments @relation(fields: [enrollment_id], references: [id], onDelete: Cascade)
+}

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,15 +1,90 @@
-/**
- * Seed script placeholder.
- *
- * Use this file to populate the database with initial data.
- * Run `npm run db:seed` from the backend directory after installing dependencies.
- */
+import { PrismaClient } from '@prisma/client';
 
-async function main() {
-  console.info('Seed script not yet implemented.');
+const prisma = new PrismaClient();
+
+async function seedRoles() {
+  const defaultRoles: Array<{ id: number; name: string }> = [
+    { id: 1, name: 'student' },
+    { id: 2, name: 'instructor' },
+    { id: 3, name: 'admin' },
+    { id: 4, name: 'registrar' },
+  ];
+
+  for (const role of defaultRoles) {
+    await prisma.roles.upsert({
+      where: { name: role.name },
+      update: {},
+      create: role,
+    });
+  }
 }
 
-main().catch((error) => {
-  console.error('Seed script failed:', error);
-  process.exit(1);
-});
+async function seedAdminUser() {
+  const adminEmail = 'admin@iroha.local';
+  const adminRole = await prisma.roles.findUnique({
+    where: { name: 'admin' },
+  });
+
+  if (!adminRole) {
+    throw new Error('Admin role must exist before creating the admin user.');
+  }
+
+  const adminUser = await prisma.users.upsert({
+    where: { email: adminEmail },
+    update: {},
+    create: {
+      email: adminEmail,
+      first_name: 'System',
+      last_name: 'Admin',
+      password_hash: '$argon2id$v=19$m=65536,t=3,p=4$YXJnb24yc2VjcmV0$2VhbmRyb21zZWVkYWRtaW4=',
+      locale: 'en',
+      timezone: 'Asia/Riyadh',
+    },
+  });
+
+  await prisma.user_roles.upsert({
+    where: {
+      user_id_role_id: {
+        user_id: adminUser.id,
+        role_id: adminRole.id,
+      },
+    },
+    update: {},
+    create: {
+      user_id: adminUser.id,
+      role_id: adminRole.id,
+    },
+  });
+}
+
+async function seedSeason() {
+  await prisma.seasons.upsert({
+    where: { code: '2025-SUM' },
+    update: {},
+    create: {
+      code: '2025-SUM',
+      title: 'Summer 2025 Intensive',
+      start_date: new Date('2025-06-01'),
+      end_date: new Date('2025-08-31'),
+      enrollment_open: new Date('2025-04-01T08:00:00Z'),
+      enrollment_close: new Date('2025-05-20T23:59:00Z'),
+      status: 'scheduled',
+    },
+  });
+}
+
+async function main() {
+  await seedRoles();
+  await seedAdminUser();
+  await seedSeason();
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (error) => {
+    console.error('Seed script failed:', error);
+    await prisma.$disconnect();
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- define the Prisma schema for users, roles, enrollments, learning content, and related enums
- add a TypeScript seed script that upserts default roles, an admin user, and a sample 2025-SUM season
- expose npm scripts for generating the client, running migrations, database seeding, and Prisma Studio

## Testing
- `npm run db:generate`
- `npm run db:seed` *(fails: DATABASE_URL not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4854b3458832f86d787fac8a16c3d