### PR TITLE
chore: document remote mysql setup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+DATABASE_URL="mysql://u331221487_mmasabi:__ENCODED_PASSWORD__@srv1725.hstgr.io:3306/u331221487_irohaDB?sslaccept=accept"
+# or using the IP:
+# DATABASE_URL="mysql://u331221487_mmasabi:__ENCODED_PASSWORD__@195.35.59.21:3306/u331221487_irohaDB?sslaccept=accept"
+# Optional (if Prisma needs a shadow DB on the host):
+# SHADOW_DATABASE_URL="mysql://u331221487_mmasabi:__ENCODED_PASSWORD__@srv1725.hstgr.io:3306/u331221487_irohaDB_shadow?sslaccept=accept"
+APP_TIMEZONE="Asia/Riyadh"
+
+# Replace __ENCODED_PASSWORD__ with the URL-encoded password where `@` becomes `%40`.

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,3 @@
+.env
+.env.*
+!.env.example

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,21 @@
+# Backend
+
+## Database Connection (Remote MySQL)
+
+1. In the hosting panel, add the server/client IP to the Remote MySQL allowlist.
+2. Create a local `.env` (do **NOT** commit):
+   ```env
+   DATABASE_URL="mysql://u331221487_mmasabi:Musabi%400594332524@srv1725.hstgr.io:3306/u331221487_irohaDB?sslaccept=accept"
+   ```
+3. Run:
+   ```bash
+   npm i
+   npm run db:generate
+   npm run db:migrate   # first time (or use db:deploy on production)
+   npm run db:seed
+   ```
+
+**Notes**
+
+- If SSL errors occur, keep `?sslaccept=accept` (switch to strict later).
+- On shared hosts that block shadow DB, set `SHADOW_DATABASE_URL` or run `db:deploy` using generated migrations.

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "db:generate": "prisma generate",
-    "db:migrate": "prisma migrate dev",
+    "db:migrate": "prisma migrate dev --name init",
+    "db:deploy": "prisma migrate deploy",
     "db:seed": "ts-node prisma/seed.ts",
     "db:studio": "prisma studio"
   },


### PR DESCRIPTION
## Summary
- add a production-style MySQL connection template and timezone to the backend env example
- ensure env files remain ignored while keeping the template committed
- document remote database usage and expose Prisma database workflow scripts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d488e7c9b4832fab6d59988735b64c