### PR TITLE
Configure Prisma env management

### DIFF
--- a/.github/workflows/db-deploy.yml
+++ b/.github/workflows/db-deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy Prisma Migrations
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, staging ]
+    paths:
+      - 'backend/prisma/migrations/**'
+      - 'backend/prisma/schema.prisma'
+jobs:
+  migrate-stage:
+    if: github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: backend } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'backend/package-lock.json'
+      - run: npm ci
+      - run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.STAGE_DATABASE_URL }}
+
+  migrate-prod:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: backend } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'backend/package-lock.json'
+      - run: npm ci
+      - run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,8 +1,12 @@
-DATABASE_URL="mysql://u331221487_mmasabi:__ENCODED_PASSWORD__@srv1725.hstgr.io:3306/u331221487_irohaDB?sslaccept=accept"
-# or using the IP:
-# DATABASE_URL="mysql://u331221487_mmasabi:__ENCODED_PASSWORD__@195.35.59.21:3306/u331221487_irohaDB?sslaccept=accept"
-# Optional (if Prisma needs a shadow DB on the host):
-# SHADOW_DATABASE_URL="mysql://u331221487_mmasabi:__ENCODED_PASSWORD__@srv1725.hstgr.io:3306/u331221487_irohaDB_shadow?sslaccept=accept"
+# Local/Dev (replace placeholders before running locally)
+DATABASE_URL="mysql://__DB_USER__:__ENCODED_PASSWORD__@__HOST__:3306/__DB_NAME__?sslaccept=accept"
 APP_TIMEZONE="Asia/Riyadh"
 
-# Replace __ENCODED_PASSWORD__ with the URL-encoded password where `@` becomes `%40`.
+# Notes:
+# - URL-encode the password. Example: '@' becomes '%40'.
+# - For shared hosts that require a shadow DB during migrate dev:
+#   SHADOW_DATABASE_URL="mysql://__DB_USER__:__ENCODED_PASSWORD__@__HOST__:3306/__DB_NAME___shadow?sslaccept=accept"
+
+# Staging/Production are injected via GitHub Secrets at deploy time:
+#   STAGE_DATABASE_URL   (GitHub Secret)
+#   PROD_DATABASE_URL    (GitHub Secret)

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,21 +1,28 @@
 # Backend
 
-## Database Connection (Remote MySQL)
+## Database Environments
 
-1. In the hosting panel, add the server/client IP to the Remote MySQL allowlist.
-2. Create a local `.env` (do **NOT** commit):
-   ```env
-   DATABASE_URL="mysql://u331221487_mmasabi:Musabi%400594332524@srv1725.hstgr.io:3306/u331221487_irohaDB?sslaccept=accept"
-   ```
-3. Run:
+### Local Development
+
+1. Copy `.env.example` to `.env.development.local` and replace the placeholders with your real credentials. Make sure the password in `DATABASE_URL` is URL-encoded.
+2. Install dependencies and prepare the database:
    ```bash
    npm i
    npm run db:generate
-   npm run db:migrate   # first time (or use db:deploy on production)
-   npm run db:seed
+   npm run db:migrate:dev
+   npm run db:seed:dev
    ```
 
-**Notes**
+### Staging
 
-- If SSL errors occur, keep `?sslaccept=accept` (switch to strict later).
-- On shared hosts that block shadow DB, set `SHADOW_DATABASE_URL` or run `db:deploy` using generated migrations.
+- For local staging tests, create `.env.staging.local` and set `DATABASE_URL` (and optional `SHADOW_DATABASE_URL`).
+- In CI/CD, inject the `STAGE_DATABASE_URL` GitHub Secret so workflows can run `prisma migrate deploy` without committing credentials.
+
+### Production (GitHub Deployments)
+
+- In the GitHub repository settings, add a `PROD_DATABASE_URL` secret. The GitHub Actions workflow will run `prisma migrate deploy` using this value whenever migrations change on the `main` branch.
+
+### Additional Notes
+
+- Always URL-encode special characters in passwords (for example, replace `@` with `%40`).
+- Shared hosts that require a dedicated shadow database can use the optional `SHADOW_DATABASE_URL` variable, following the pattern in `.env.example`.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
         "@prisma/client": "^5.12.1"
       },
       "devDependencies": {
+        "dotenv-cli": "^7.3.0",
         "prisma": "^5.12.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.3"
@@ -204,6 +205,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -212,6 +228,45 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-7.3.0.tgz",
+      "integrity": "sha512-314CA4TyK34YEJ6ntBf80eUY+t1XaFLyem1k9P0sX1gn30qThZ5qZr/ZwE318gEnzyYP9yj9HJk6SqwE0upkfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fsevents": {
@@ -229,12 +284,39 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/prisma": {
       "version": "5.22.0",
@@ -254,6 +336,29 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ts-node": {
@@ -328,6 +433,22 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,10 +4,14 @@
   "private": true,
   "scripts": {
     "db:generate": "prisma generate",
-    "db:migrate": "prisma migrate dev --name init",
-    "db:deploy": "prisma migrate deploy",
-    "db:seed": "ts-node prisma/seed.ts",
-    "db:studio": "prisma studio"
+    "db:migrate": "npm run db:migrate:dev",
+    "db:migrate:dev": "dotenv -e .env.development.local -- prisma migrate dev",
+    "db:deploy": "npm run db:deploy:prod",
+    "db:deploy:stage": "dotenv -e .env.staging.local -- prisma migrate deploy",
+    "db:deploy:prod": "prisma migrate deploy",
+    "db:seed": "npm run db:seed:dev",
+    "db:seed:dev": "dotenv -e .env.development.local -- ts-node prisma/seed.ts",
+    "db:studio": "dotenv -e .env.development.local -- prisma studio"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"
@@ -16,6 +20,7 @@
     "@prisma/client": "^5.12.1"
   },
   "devDependencies": {
+    "dotenv-cli": "^7.3.0",
     "prisma": "^5.12.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.3"


### PR DESCRIPTION
## Summary
- replace the backend `.env.example` with placeholder guidance for remote MySQL usage
- add dotenv-powered Prisma scripts and document local/staging/production database flows
- configure a GitHub Actions workflow to deploy Prisma migrations using stage/prod secrets

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d48b9ffb2c832f9710cf2af17a4737