### PR TITLE
Add production Prisma deploy workflow health checks

### DIFF
--- a/.github/workflows/db-deploy.yml
+++ b/.github/workflows/db-deploy.yml
@@ -22,6 +22,10 @@ jobs:
       - run: npx prisma migrate deploy
         env:
           DATABASE_URL: ${{ secrets.STAGE_DATABASE_URL }}
+      - name: DB health (stage)
+        run: npm run db:health
+        env:
+          DATABASE_URL: ${{ secrets.STAGE_DATABASE_URL }}
 
   migrate-prod:
     if: github.ref == 'refs/heads/main'
@@ -36,5 +40,9 @@ jobs:
           cache-dependency-path: 'backend/package-lock.json'
       - run: npm ci
       - run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+      - name: DB health (prod)
+        run: npm run db:health
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,6 @@ APP_TIMEZONE="Asia/Riyadh"
 # Staging/Production are injected via GitHub Secrets at deploy time:
 #   STAGE_DATABASE_URL   (GitHub Secret)
 #   PROD_DATABASE_URL    (GitHub Secret)
+# Production uses GitHub Secrets, not local files:
+#   PROD_DATABASE_URL  -> mysql://USER:ENCODED_PASS@HOST:3306/DB?sslaccept=accept
+# Do not commit .env files.

--- a/backend/README.md
+++ b/backend/README.md
@@ -26,3 +26,17 @@
 
 - Always URL-encode special characters in passwords (for example, replace `@` with `%40`).
 - Shared hosts that require a dedicated shadow database can use the optional `SHADOW_DATABASE_URL` variable, following the pattern in `.env.example`.
+
+## Production DB via GitHub Secrets
+
+### Adding the production secret
+
+1. In GitHub → Settings → Secrets → Actions → **New repository secret**:
+   - **Name**: `PROD_DATABASE_URL`
+   - **Value example**: `mysql://u331221487_mmasabi:Musabi%400594332524@srv1725.hstgr.io:3306/u331221487_irohaDB?sslaccept=accept`
+2. Passwords must be URL-encoded (for example, `@` becomes `%40`).
+3. Allowlist the GitHub runner IP in your Hostinger **Remote MySQL** settings if required.
+
+### Deploying production migrations
+
+- Push a commit to `main` that modifies `backend/prisma/migrations/**` or trigger the "Deploy Prisma Migrations" workflow manually.

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "db:deploy:prod": "prisma migrate deploy",
     "db:seed": "npm run db:seed:dev",
     "db:seed:dev": "dotenv -e .env.development.local -- ts-node prisma/seed.ts",
+    "db:health": "ts-node scripts/db-test.ts",
     "db:studio": "dotenv -e .env.development.local -- prisma studio"
   },
   "prisma": {

--- a/backend/scripts/db-test.ts
+++ b/backend/scripts/db-test.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main(): Promise<number> {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    console.log('Database connection healthy.');
+    return 0;
+  } catch (error: unknown) {
+    const code = (error as { code?: string }).code ?? 'UNKNOWN';
+    const message = (error as { message?: string }).message ?? String(error);
+    console.error(`Database health check failed [${code}]: ${message}`);
+    return 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main()
+  .then((code) => {
+    process.exit(code);
+  })
+  .catch((error) => {
+    console.error('Unexpected error during database health check:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add a TypeScript database health check script and npm script entry
- document production database secret setup for Hostinger deployments
- extend the Prisma deploy workflow with staging/production health probes using secrets

## Testing
- not run (requires database credentials)


------
https://chatgpt.com/codex/tasks/task_e_68d49060a3d4832f8869b72fe94b46f8