### PR TITLE
feat: add enrollment module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { PrismaModule } from './prisma/prisma.module';
+import { EnrollmentsModule } from './modules/enrollments/enrollments.module';
 
 @Module({
   imports: [
@@ -10,6 +11,7 @@ import { PrismaModule } from './prisma/prisma.module';
     PrismaModule,
     UsersModule,
     AuthModule,
+    EnrollmentsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/enrollments/dto/create-enrollment.dto.ts
+++ b/backend/src/modules/enrollments/dto/create-enrollment.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class CreateEnrollmentDto {
+  @ApiProperty({ description: 'Identifier of the course to enroll in', minimum: 1, example: 101 })
+  @IsInt()
+  @Min(1)
+  courseId!: number;
+
+  @ApiPropertyOptional({ description: 'Specific section to join', minimum: 1, example: 12 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  sectionId?: number;
+}

--- a/backend/src/modules/enrollments/dto/index.ts
+++ b/backend/src/modules/enrollments/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './create-enrollment.dto';

--- a/backend/src/modules/enrollments/enrollments.controller.spec.ts
+++ b/backend/src/modules/enrollments/enrollments.controller.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EnrollmentsController } from './enrollments.controller';
+import { EnrollmentsService, EnrollmentCreationResult, EnrollmentReportItem, MyEnrollmentSummary } from './enrollments.service';
+import { EnrollmentStatus } from '@prisma/client';
+
+describe('EnrollmentsController', () => {
+  let controller: EnrollmentsController;
+  let service: jest.Mocked<EnrollmentsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EnrollmentsController],
+      providers: [
+        {
+          provide: EnrollmentsService,
+          useValue: {
+            createEnrollment: jest.fn(),
+            getMyEnrollments: jest.fn(),
+            getEnrollmentReport: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<EnrollmentsController>(EnrollmentsController);
+    service = module.get(EnrollmentsService);
+  });
+
+  it('creates an enrollment for the authenticated user', async () => {
+    const expected: EnrollmentCreationResult = {
+      enrollmentId: '123',
+      status: EnrollmentStatus.pending,
+      seatsLeft: 4,
+    };
+    service.createEnrollment.mockResolvedValue(expected);
+
+    const result = await controller.create(
+      { user: { sub: '42' } } as any,
+      { courseId: 10, sectionId: 3 },
+    );
+
+    expect(result).toEqual(expected);
+    expect(service.createEnrollment).toHaveBeenCalledWith('42', { courseId: 10, sectionId: 3 });
+  });
+
+  it('returns enrollments for the authenticated user', async () => {
+    const expected: MyEnrollmentSummary[] = [
+      {
+        id: '1',
+        status: EnrollmentStatus.active,
+        enrolledAt: new Date('2024-01-01T00:00:00.000Z'),
+        course: { id: '5', code: 'JP-101', title: 'Intro' },
+        section: null,
+      },
+    ];
+    service.getMyEnrollments.mockResolvedValue(expected);
+
+    const result = await controller.getMine({ user: { sub: '42' } } as any);
+
+    expect(result).toEqual(expected);
+    expect(service.getMyEnrollments).toHaveBeenCalledWith('42');
+  });
+
+  it('returns the enrollment report', async () => {
+    const expected: EnrollmentReportItem[] = [
+      {
+        courseId: '10',
+        code: 'JP-101',
+        title: 'Intro',
+        capacity: 20,
+        active: 10,
+        pending: 5,
+        waitlisted: 2,
+        completed: 1,
+        cancelled: 1,
+        seatsLeft: 5,
+      },
+    ];
+    service.getEnrollmentReport.mockResolvedValue(expected);
+
+    const result = await controller.getReport('WINTER-2024');
+
+    expect(result).toEqual(expected);
+    expect(service.getEnrollmentReport).toHaveBeenCalledWith('WINTER-2024');
+  });
+});

--- a/backend/src/modules/enrollments/enrollments.controller.ts
+++ b/backend/src/modules/enrollments/enrollments.controller.ts
@@ -1,0 +1,184 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Req,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiExtraModels,
+  ApiOkResponse,
+  ApiOperation,
+  ApiProperty,
+  ApiPropertyOptional,
+  ApiQuery,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { UserRole } from '../../common/enums/user-role.enum';
+import { CreateEnrollmentDto } from './dto';
+import { EnrollmentsService, EnrollmentCreationResult, EnrollmentReportItem, MyEnrollmentSummary } from './enrollments.service';
+import { JwtPayload } from '../../auth/jwt-payload.interface';
+import { EnrollmentStatus } from '@prisma/client';
+
+class EnrollmentResponseDto implements EnrollmentCreationResult {
+  @ApiProperty({ description: 'Identifier of the created enrollment', example: '123' })
+  enrollmentId!: string;
+
+  @ApiProperty({ enum: EnrollmentStatus, example: EnrollmentStatus.pending })
+  status!: EnrollmentStatus;
+
+  @ApiProperty({ description: 'Seats remaining for the course', example: 12 })
+  seatsLeft!: number;
+}
+
+class EnrollmentCourseDto {
+  @ApiProperty({ example: '42' })
+  id!: string;
+
+  @ApiProperty({ example: 'JP-101' })
+  code!: string;
+
+  @ApiProperty({ example: 'Introduction to Japanese' })
+  title!: string;
+}
+
+class EnrollmentSectionDto {
+  @ApiProperty({ example: '17' })
+  id!: string;
+
+  @ApiPropertyOptional({ example: 'Evening Section' })
+  title?: string | null;
+}
+
+class MyEnrollmentDto implements MyEnrollmentSummary {
+  @ApiProperty({ example: '501' })
+  id!: string;
+
+  @ApiProperty({ enum: EnrollmentStatus, example: EnrollmentStatus.waitlisted })
+  status!: EnrollmentStatus;
+
+  @ApiProperty({ type: String, format: 'date-time', example: '2024-06-01T12:00:00.000Z' })
+  enrolledAt!: Date;
+
+  @ApiProperty({ type: EnrollmentCourseDto })
+  course!: EnrollmentCourseDto;
+
+  @ApiPropertyOptional({ type: EnrollmentSectionDto })
+  section?: EnrollmentSectionDto | null;
+}
+
+class EnrollmentReportItemDto implements EnrollmentReportItem {
+  @ApiProperty({ example: '88' })
+  courseId!: string;
+
+  @ApiProperty({ example: 'JP-201' })
+  code!: string;
+
+  @ApiProperty({ example: 'Intermediate Japanese' })
+  title!: string;
+
+  @ApiProperty({ example: 25 })
+  capacity!: number;
+
+  @ApiProperty({ example: 18 })
+  active!: number;
+
+  @ApiProperty({ example: 3 })
+  pending!: number;
+
+  @ApiProperty({ example: 5 })
+  waitlisted!: number;
+
+  @ApiProperty({ example: 2 })
+  completed!: number;
+
+  @ApiProperty({ example: 1 })
+  cancelled!: number;
+
+  @ApiProperty({ example: 4 })
+  seatsLeft!: number;
+}
+
+@ApiTags('enrollments')
+@ApiExtraModels(EnrollmentResponseDto)
+@Controller()
+export class EnrollmentsController {
+  constructor(private readonly enrollmentsService: EnrollmentsService) {}
+
+  @Post('enrollments')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Submit a new enrollment for the authenticated user' })
+  @ApiCreatedResponse({
+    description: 'Enrollment outcome',
+    content: {
+      'application/json': {
+        schema: { $ref: getSchemaPath(EnrollmentResponseDto) },
+        examples: {
+          pending: {
+            summary: 'Pending enrollment when seats are available',
+            value: { enrollmentId: '321', status: EnrollmentStatus.pending, seatsLeft: 9 },
+          },
+          waitlisted: {
+            summary: 'Waitlisted enrollment when the course is full',
+            value: { enrollmentId: '654', status: EnrollmentStatus.waitlisted, seatsLeft: 0 },
+          },
+        },
+      },
+    },
+  })
+  async create(@Req() req: Request, @Body() dto: CreateEnrollmentDto): Promise<EnrollmentResponseDto> {
+    const payload = req.user as JwtPayload | undefined;
+    const userId = payload?.sub;
+
+    if (!userId) {
+      throw new UnauthorizedException('Missing authenticated user identifier');
+    }
+
+    return this.enrollmentsService.createEnrollment(userId, dto);
+  }
+
+  @Get('enrollments/mine')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List enrollments for the authenticated user' })
+  @ApiOkResponse({ type: MyEnrollmentDto, isArray: true })
+  async getMine(@Req() req: Request): Promise<MyEnrollmentDto[]> {
+    const payload = req.user as JwtPayload | undefined;
+    const userId = payload?.sub;
+
+    if (!userId) {
+      throw new UnauthorizedException('Missing authenticated user identifier');
+    }
+
+    return this.enrollmentsService.getMyEnrollments(userId);
+  }
+
+  @Get('reports/enrollment')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.Admin)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Admin enrollment report aggregated by course' })
+  @ApiQuery({ name: 'season', description: 'Season code to filter courses', example: 'SPRING-2024' })
+  @ApiOkResponse({ type: EnrollmentReportItemDto, isArray: true })
+  async getReport(@Query('season') seasonCode: string): Promise<EnrollmentReportItemDto[]> {
+    const normalized = seasonCode?.trim();
+
+    if (!normalized) {
+      throw new BadRequestException('Query parameter "season" is required');
+    }
+
+    return this.enrollmentsService.getEnrollmentReport(normalized);
+  }
+}

--- a/backend/src/modules/enrollments/enrollments.module.ts
+++ b/backend/src/modules/enrollments/enrollments.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { EnrollmentsController } from './enrollments.controller';
+import { EnrollmentsService } from './enrollments.service';
+
+@Module({
+  controllers: [EnrollmentsController],
+  providers: [EnrollmentsService],
+})
+export class EnrollmentsModule {}

--- a/backend/src/modules/enrollments/enrollments.service.ts
+++ b/backend/src/modules/enrollments/enrollments.service.ts
@@ -1,0 +1,255 @@
+import {
+  BadRequestException,
+  ConflictException,
+  HttpException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { EnrollmentStatus, Prisma, seasons } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateEnrollmentDto } from './dto';
+
+export interface EnrollmentCreationResult {
+  enrollmentId: string;
+  status: EnrollmentStatus;
+  seatsLeft: number;
+}
+
+export interface MyEnrollmentSummary {
+  id: string;
+  status: EnrollmentStatus;
+  enrolledAt: Date;
+  course: {
+    id: string;
+    code: string;
+    title: string;
+  };
+  section?: {
+    id: string;
+    title?: string | null;
+  } | null;
+}
+
+export interface EnrollmentReportItem {
+  courseId: string;
+  code: string;
+  title: string;
+  capacity: number;
+  active: number;
+  pending: number;
+  waitlisted: number;
+  completed: number;
+  cancelled: number;
+  seatsLeft: number;
+}
+
+type TransactionClient = Prisma.TransactionClient;
+
+@Injectable()
+export class EnrollmentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createEnrollment(userId: string, dto: CreateEnrollmentDto): Promise<EnrollmentCreationResult> {
+    const courseId = BigInt(dto.courseId);
+    const sectionId = dto.sectionId ? BigInt(dto.sectionId) : undefined;
+    const userIdNumeric = BigInt(userId);
+
+    return this.prisma.$transaction(
+      async (tx) => {
+        const course = await tx.courses.findUnique({
+          where: { id: courseId },
+          include: { season: true },
+        });
+
+        if (!course) {
+          throw new NotFoundException('Course not found');
+        }
+
+        if (!this.canEnrollWindow(course.season)) {
+          throw new HttpException('Enrollment window is closed for this course', 423);
+        }
+
+        if (sectionId) {
+          const section = await tx.sections.findUnique({
+            where: { id: sectionId },
+            select: { course_id: true },
+          });
+
+          if (!section || section.course_id !== courseId) {
+            throw new BadRequestException('Section does not belong to the selected course');
+          }
+        }
+
+        const existing = await tx.enrollments.findUnique({
+          where: {
+            user_id_course_id: {
+              user_id: userIdNumeric,
+              course_id: courseId,
+            },
+          },
+        });
+
+        if (existing) {
+          const blockingStatuses: EnrollmentStatus[] = [
+            EnrollmentStatus.active,
+            EnrollmentStatus.pending,
+            EnrollmentStatus.waitlisted,
+            EnrollmentStatus.completed,
+          ];
+
+          if (blockingStatuses.includes(existing.status)) {
+            throw new ConflictException('User is already enrolled in this course');
+          }
+
+          if (existing.status === EnrollmentStatus.cancelled) {
+            await tx.enrollments.delete({ where: { id: existing.id } });
+          }
+        }
+
+        const activePendingCount = await tx.enrollments.count({
+          where: {
+            course_id: courseId,
+            status: { in: [EnrollmentStatus.active, EnrollmentStatus.pending] },
+          },
+        });
+
+        const seatsLeftBefore = course.capacity - activePendingCount;
+        const status =
+          seatsLeftBefore > 0 ? EnrollmentStatus.pending : EnrollmentStatus.waitlisted;
+
+        const enrollment = await tx.enrollments.create({
+          data: {
+            user_id: userIdNumeric,
+            course_id: courseId,
+            section_id: sectionId ?? null,
+            status,
+          },
+        });
+
+        const seatsLeft = await this.computeSeatsLeft(courseId, tx);
+
+        return {
+          enrollmentId: enrollment.id.toString(),
+          status,
+          seatsLeft,
+        };
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+  }
+
+  async getMyEnrollments(userId: string): Promise<MyEnrollmentSummary[]> {
+    const enrollments = await this.prisma.enrollments.findMany({
+      where: { user_id: BigInt(userId) },
+      include: {
+        course: { select: { id: true, code: true, title: true } },
+        section: { select: { id: true, title: true } },
+      },
+      orderBy: { enrolled_at: 'desc' },
+    });
+
+    return enrollments.map((enrollment) => ({
+      id: enrollment.id.toString(),
+      status: enrollment.status,
+      enrolledAt: enrollment.enrolled_at,
+      course: {
+        id: enrollment.course.id.toString(),
+        code: enrollment.course.code,
+        title: enrollment.course.title,
+      },
+      section: enrollment.section
+        ? {
+            id: enrollment.section.id.toString(),
+            title: enrollment.section.title,
+          }
+        : null,
+    }));
+  }
+
+  async getEnrollmentReport(seasonCode: string): Promise<EnrollmentReportItem[]> {
+    const season = await this.prisma.seasons.findUnique({
+      where: { code: seasonCode },
+      select: { id: true },
+    });
+
+    if (!season) {
+      throw new NotFoundException('Season not found');
+    }
+
+    const courses = await this.prisma.courses.findMany({
+      where: { season_id: season.id },
+      select: { id: true, code: true, title: true, capacity: true },
+      orderBy: { code: 'asc' },
+    });
+
+    if (courses.length === 0) {
+      return [];
+    }
+
+    const courseIds = courses.map((course) => course.id);
+
+    const grouped = await this.prisma.enrollments.groupBy({
+      by: ['course_id', 'status'],
+      where: { course_id: { in: courseIds } },
+      _count: { _all: true },
+    });
+
+    const statuses = Object.values(EnrollmentStatus) as EnrollmentStatus[];
+
+    const result: EnrollmentReportItem[] = courses.map((course) => {
+      const counts = Object.fromEntries(statuses.map((status) => [status, 0])) as Record<EnrollmentStatus, number>;
+
+      for (const item of grouped) {
+        if (item.course_id === course.id) {
+          counts[item.status] = item._count._all;
+        }
+      }
+
+      const seatsLeft = Math.max(
+        0,
+        course.capacity - (counts[EnrollmentStatus.active] + counts[EnrollmentStatus.pending]),
+      );
+
+      return {
+        courseId: course.id.toString(),
+        code: course.code,
+        title: course.title,
+        capacity: course.capacity,
+        active: counts[EnrollmentStatus.active],
+        pending: counts[EnrollmentStatus.pending],
+        waitlisted: counts[EnrollmentStatus.waitlisted],
+        completed: counts[EnrollmentStatus.completed],
+        cancelled: counts[EnrollmentStatus.cancelled],
+        seatsLeft,
+      };
+    });
+
+    return result;
+  }
+
+  async computeSeatsLeft(courseId: bigint, tx?: TransactionClient): Promise<number> {
+    const client = tx ?? this.prisma;
+    const course = await client.courses.findUnique({
+      where: { id: courseId },
+      select: { capacity: true },
+    });
+
+    if (!course) {
+      throw new NotFoundException('Course not found');
+    }
+
+    const activePending = await client.enrollments.count({
+      where: {
+        course_id: courseId,
+        status: { in: [EnrollmentStatus.active, EnrollmentStatus.pending] },
+      },
+    });
+
+    return Math.max(0, course.capacity - activePending);
+  }
+
+  canEnrollWindow(season: Pick<seasons, 'enrollment_open' | 'enrollment_close'>): boolean {
+    const now = new Date();
+    return now >= season.enrollment_open && now <= season.enrollment_close;
+  }
+}


### PR DESCRIPTION
## Summary
- add enrollments module with controller, dto, and swagger docs for enrollment creation, self listing, and admin reporting
- implement transactional enrollment service with seat accounting, waitlist handling, and capacity helpers
- cover controller contract with a unit test harness

## Testing
- npm run build
- npx jest --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d497777d40832fbbc47ac43ea85bfd