### PR TITLE
Implement enrollment checkout flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@ This repository hosts the product blueprint for **iroha (いろは)** — a seas
 - [`docs/blueprint.md`](docs/blueprint.md): end-to-end architecture, schema, API, and roadmap.
 
 Use this blueprint as the foundation for implementing the backend (NestJS), frontend (Next.js), and mobile (Flutter/React Native) clients.
+
+## Web App Environment
+
+The Next.js client expects the following environment variable when running locally:
+
+```bash
+export NEXT_PUBLIC_RETURN_URL="http://localhost:3000/payment/return"
+```
+
+This URL is shared with the payment provider to handle the browser return flow after checkout.

--- a/web/app/api/auth/me/route.ts
+++ b/web/app/api/auth/me/route.ts
@@ -1,0 +1,29 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+import type {CurrentUserResponse} from '@/types/api';
+
+export async function GET(_: NextRequest) {
+  const response = await authorizedFetch('/me', { method: 'GET' });
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json(error, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: {
+        'content-type': contentType ?? 'text/plain'
+      }
+    });
+  }
+
+  const data: CurrentUserResponse = isJson ? await response.json() : ({} as CurrentUserResponse);
+
+  return NextResponse.json(data, { status: response.status });
+}

--- a/web/app/api/enrollments/route.ts
+++ b/web/app/api/enrollments/route.ts
@@ -1,0 +1,46 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+import type {EnrollResponse} from '@/types/api';
+
+export async function POST(request: NextRequest) {
+  const payload = await request.json().catch(() => null);
+
+  if (!payload || !payload.courseId) {
+    return NextResponse.json({ message: 'courseId is required' }, { status: 400 });
+  }
+
+  const response = await authorizedFetch('/enrollments', {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  });
+
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const errorBody = await response.json().catch(() => ({}));
+      return NextResponse.json(errorBody, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: {
+        'content-type': contentType ?? 'text/plain'
+      }
+    });
+  }
+
+  const data: EnrollResponse = isJson ? await response.json() : ({} as EnrollResponse);
+
+  return NextResponse.json(
+    {
+      enrollmentId: data.enrollmentId,
+      status: data.status,
+      seats_left: data.seats_left ?? data.seatsLeft ?? null
+    },
+    { status: response.status }
+  );
+}

--- a/web/app/api/payments/[enrollmentId]/intent/route.ts
+++ b/web/app/api/payments/[enrollmentId]/intent/route.ts
@@ -1,0 +1,53 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+import type {PaymentIntentResponse} from '@/types/api';
+
+const RETURN_URL = process.env.NEXT_PUBLIC_RETURN_URL;
+
+export async function POST(_: NextRequest, {params}: { params: { enrollmentId: string } }) {
+  const {enrollmentId} = params;
+
+  if (!enrollmentId) {
+    return NextResponse.json({ message: 'enrollmentId is required' }, { status: 400 });
+  }
+
+  const body: Record<string, unknown> = {};
+  if (RETURN_URL) {
+    body.returnUrl = RETURN_URL;
+  }
+
+  const response = await authorizedFetch(`/payments/${encodeURIComponent(enrollmentId)}/intent`, {
+    method: 'POST',
+    body: JSON.stringify(body)
+  });
+
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const errorBody = await response.json().catch(() => ({}));
+      return NextResponse.json(errorBody, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: {
+        'content-type': contentType ?? 'text/plain'
+      }
+    });
+  }
+
+  const data: PaymentIntentResponse = isJson ? await response.json() : ({} as PaymentIntentResponse);
+
+  return NextResponse.json(
+    {
+      checkoutUrl: data.checkoutUrl,
+      providerRef: data.providerRef,
+      provider: data.provider
+    },
+    { status: response.status }
+  );
+}

--- a/web/app/checkout/[enrollmentId]/page.tsx
+++ b/web/app/checkout/[enrollmentId]/page.tsx
@@ -1,0 +1,100 @@
+import Link from 'next/link';
+import {cookies, headers} from 'next/headers';
+import {redirect} from 'next/navigation';
+
+import type {PaymentIntentResponse} from '@/types/api';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+
+export const dynamic = 'force-dynamic';
+
+interface CheckoutPageProps {
+  params: { enrollmentId: string };
+}
+
+async function loadIntent(enrollmentId: string): Promise<{ data: PaymentIntentResponse | null; error?: string }> {
+  const headersList = headers();
+  const cookieStore = cookies();
+
+  const host = headersList.get('x-forwarded-host') ?? headersList.get('host');
+  if (!host) {
+    return { data: null, error: 'Missing host header' };
+  }
+
+  const protocol = headersList.get('x-forwarded-proto') ?? (host.includes('localhost') ? 'http' : 'https');
+  const cookieHeader = cookieStore
+    .getAll()
+    .map(({name, value}) => `${name}=${value}`)
+    .join('; ');
+
+  try {
+    const response = await fetch(`${protocol}://${host}/api/payments/${encodeURIComponent(enrollmentId)}/intent`, {
+      method: 'POST',
+      headers: {
+        ...(cookieHeader ? { cookie: cookieHeader } : {}),
+        'Content-Type': 'application/json'
+      },
+      cache: 'no-store',
+      next: { revalidate: 0 }
+    });
+
+    const contentType = response.headers.get('content-type');
+    const isJson = contentType?.includes('application/json');
+
+    if (!response.ok) {
+      if (isJson) {
+        const body = await response.json().catch(() => ({}));
+        return { data: null, error: typeof body.message === 'string' ? body.message : 'Unable to load payment intent' };
+      }
+
+      return { data: null, error: 'Unable to load payment intent' };
+    }
+
+    if (!isJson) {
+      return { data: null, error: 'Payment intent response was not JSON' };
+    }
+
+    const data = (await response.json()) as PaymentIntentResponse;
+    return { data };
+  } catch (error) {
+    return { data: null, error: error instanceof Error ? error.message : 'Unable to load payment intent' };
+  }
+}
+
+export default async function CheckoutPage({params}: CheckoutPageProps) {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+
+  const {data, error} = await loadIntent(params.enrollmentId);
+
+  if (error) {
+    return <div className="error-state">{t('checkoutPage.error')}</div>;
+  }
+
+  if (!data) {
+    return <div className="error-state">{t('checkoutPage.error')}</div>;
+  }
+
+  if (data.checkoutUrl && data.provider !== 'mock') {
+    redirect(data.checkoutUrl);
+  }
+
+  return (
+    <section className="card" style={{ gap: '1rem' }}>
+      <h1 style={{ margin: 0 }}>{t('checkoutPage.title')}</h1>
+      <p style={{ margin: 0, color: '#4b5563' }}>{t('checkoutPage.description')}</p>
+      {data.checkoutUrl ? (
+        <a className="button" href={data.checkoutUrl ?? '#'} target="_blank" rel="noreferrer">
+          {t('checkoutPage.openCheckout')}
+        </a>
+      ) : (
+        <p style={{ margin: 0, color: '#b91c1c' }}>{t('checkoutPage.missingUrl')}</p>
+      )}
+      {data.providerRef ? (
+        <p style={{ margin: 0, color: '#6b7280' }}>{t('checkoutPage.providerRef', { ref: data.providerRef })}</p>
+      ) : null}
+      <Link href="/dashboard" className="button" style={{ backgroundColor: '#6b7280' }}>
+        {t('checkoutPage.dashboardCta')}
+      </Link>
+    </section>
+  );
+}

--- a/web/app/enroll/[courseId]/EnrollForm.tsx
+++ b/web/app/enroll/[courseId]/EnrollForm.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import Link from 'next/link';
+import {FormEvent, useEffect, useState} from 'react';
+import {useRouter} from 'next/navigation';
+
+import type {Section} from '@/lib/api';
+import type {EnrollResponse} from '@/types/api';
+
+type ToastState = {
+  variant: 'success' | 'error';
+  message: string;
+};
+
+interface EnrollFormProps {
+  courseId: string;
+  sections: Section[];
+  labels: {
+    submit: string;
+    loading: string;
+    sectionLabel: string;
+    sectionPlaceholder: string;
+    noSections: string;
+    optional: string;
+    waitlistedTitle: string;
+    waitlistedDescription: string;
+    waitlistedSeats: string;
+    dashboardCta: string;
+    successToast: string;
+    errorToast: string;
+  };
+}
+
+export function EnrollForm({courseId, sections, labels}: EnrollFormProps) {
+  const router = useRouter();
+  const [sectionId, setSectionId] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+  const [waitlisted, setWaitlisted] = useState<EnrollResponse | null>(null);
+
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+
+    const timeout = setTimeout(() => setToast(null), 5000);
+    return () => clearTimeout(timeout);
+  }, [toast]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setToast(null);
+    setWaitlisted(null);
+
+    try {
+      const response = await fetch('/api/enrollments', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          courseId,
+          ...(sectionId ? { sectionId } : {})
+        }),
+        cache: 'no-store'
+      });
+
+      if (!response.ok) {
+        throw new Error('Enrollment failed');
+      }
+
+      const data = (await response.json()) as EnrollResponse;
+      setToast({ variant: 'success', message: labels.successToast });
+
+      if (data.status === 'waitlisted') {
+        setWaitlisted(data);
+        return;
+      }
+
+      if (data.status === 'pending') {
+        router.push(`/checkout/${data.enrollmentId}`);
+        return;
+      }
+
+      router.push('/dashboard');
+    } catch (error) {
+      setToast({ variant: 'error', message: labels.errorToast });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const waitlistSeats = waitlisted ? waitlisted.seats_left ?? waitlisted.seatsLeft ?? null : null;
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      {toast ? (
+        <div className={`toast toast--${toast.variant}`}>{toast.message}</div>
+      ) : null}
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="section">
+          {labels.sectionLabel}
+          {sections.length ? <span style={{ color: '#6b7280' }}> · {labels.optional}</span> : null}
+        </label>
+        {sections.length ? (
+          <select
+            id="section"
+            name="section"
+            value={sectionId}
+            onChange={(event) => setSectionId(event.target.value)}
+            style={{
+              padding: '0.75rem',
+              borderRadius: '0.75rem',
+              border: '1px solid #d1d5db',
+              backgroundColor: '#fff',
+              fontSize: '1rem'
+            }}
+          >
+            <option value="">{labels.sectionPlaceholder}</option>
+            {sections.map((section) => (
+              <option key={section.id} value={section.id}>
+                {section.title ?? section.id}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <p style={{ margin: 0, color: '#6b7280' }}>{labels.noSections}</p>
+        )}
+      </div>
+
+      <button
+        type="submit"
+        className="button"
+        disabled={isSubmitting}
+        style={{
+          alignSelf: 'flex-start',
+          opacity: isSubmitting ? 0.7 : 1,
+          cursor: isSubmitting ? 'not-allowed' : 'pointer'
+        }}
+      >
+        {isSubmitting ? labels.loading : labels.submit}
+      </button>
+
+      {waitlisted ? (
+        <div
+          style={{
+            borderRadius: '0.75rem',
+            border: '1px solid #f59e0b',
+            background: '#fef3c7',
+            padding: '1.25rem'
+          }}
+        >
+          <h2 style={{ marginTop: 0 }}>{labels.waitlistedTitle}</h2>
+          <p style={{ marginBottom: '0.5rem' }}>{labels.waitlistedDescription}</p>
+          {waitlistSeats != null ? (
+            <p style={{ marginTop: 0 }}>{labels.waitlistedSeats.replace('{count}', String(waitlistSeats))}</p>
+          ) : null}
+          <Link
+            className="button"
+            href="/dashboard"
+            style={{
+              marginTop: '1rem',
+              backgroundColor: '#f59e0b',
+              color: '#1f2937'
+            }}
+          >
+            {labels.dashboardCta}
+          </Link>
+        </div>
+      ) : null}
+    </form>
+  );
+}

--- a/web/app/enroll/[courseId]/page.tsx
+++ b/web/app/enroll/[courseId]/page.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+
+import {fetchCourseById, fetchSectionsByCourse} from '@/lib/api';
+import {formatCurrency} from '@/lib/format';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+
+import {EnrollForm} from './EnrollForm';
+
+export const dynamic = 'force-dynamic';
+
+interface EnrollPageProps {
+  params: { courseId: string };
+}
+
+export default async function EnrollPage({params}: EnrollPageProps) {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+
+  const [{course}, {sections}] = await Promise.all([
+    fetchCourseById(params.courseId),
+    fetchSectionsByCourse(params.courseId)
+  ]);
+
+  if (!course) {
+    return <div className="error-state">{t('errors.generic')}</div>;
+  }
+
+  const priceLabel = formatCurrency({ amountCents: course.priceCents, currency: course.currency, locale });
+
+  return (
+    <article className="card" style={{ padding: '2rem', gap: '1.5rem' }}>
+      <header>
+        <Link href={`/courses/${course.id}`} style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem', color: '#2563eb' }}>
+          ← {t('actions.view')}
+        </Link>
+        <h1 style={{ marginTop: '1rem', marginBottom: '0.5rem' }}>{t('enrollPage.title', { title: course.title })}</h1>
+        {priceLabel ? <p style={{ margin: 0, color: '#4b5563' }}>{t('enrollPage.price', { price: priceLabel })}</p> : null}
+      </header>
+
+      <EnrollForm
+        courseId={course.id}
+        sections={sections}
+        labels={{
+          submit: t('enrollPage.submit'),
+          sectionLabel: t('enrollPage.sectionLabel'),
+          sectionPlaceholder: t('enrollPage.sectionPlaceholder'),
+          noSections: t('enrollPage.noSections'),
+          optional: t('enrollPage.optional'),
+          waitlistedTitle: t('enrollPage.waitlistedTitle'),
+          waitlistedDescription: t('enrollPage.waitlistedDescription'),
+          waitlistedSeats: t('enrollPage.waitlistedSeats'),
+          dashboardCta: t('enrollPage.dashboardCta'),
+          successToast: t('enrollPage.successToast'),
+          errorToast: t('enrollPage.errorToast'),
+          loading: t('enrollPage.loading')
+        }}
+      />
+    </article>
+  );
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -100,6 +100,15 @@ section + section {
   background-color: #1d4ed8;
 }
 
+.nav-link {
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.nav-link:hover {
+  color: #2563eb;
+}
+
 .empty-state,
 .error-state {
   border-radius: 0.75rem;
@@ -119,4 +128,20 @@ section + section {
   main {
     padding: 1.5rem 1rem;
   }
+}
+
+.toast {
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+}
+
+.toast--success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.toast--error {
+  background: #fee2e2;
+  color: #b91c1c;
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,9 +1,11 @@
 import type {Metadata} from 'next';
 import Link from 'next/link';
+import {cookies, headers} from 'next/headers';
 import {ReactNode} from 'react';
 
 import {IntlProvider} from '@/components/IntlProvider';
 import {detectRequestLocale, getMessages, getTranslator} from '@/lib/i18n';
+import type {CurrentUserResponse} from '@/types/api';
 
 import './globals.css';
 
@@ -16,11 +18,46 @@ type RootLayoutProps = {
   children: ReactNode;
 };
 
-export default function RootLayout({children}: RootLayoutProps) {
+async function getCurrentUser(): Promise<CurrentUserResponse | null> {
+  try {
+    const headersList = headers();
+    const cookieStore = cookies();
+    const host = headersList.get('x-forwarded-host') ?? headersList.get('host');
+
+    if (!host) {
+      return null;
+    }
+
+    const protocol = headersList.get('x-forwarded-proto') ?? (host.includes('localhost') ? 'http' : 'https');
+    const cookieHeader = cookieStore
+      .getAll()
+      .map(({name, value}) => `${name}=${value}`)
+      .join('; ');
+
+    const response = await fetch(`${protocol}://${host}/api/auth/me`, {
+      method: 'GET',
+      headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+      cache: 'no-store',
+      next: { revalidate: 0 }
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as CurrentUserResponse;
+  } catch (error) {
+    return null;
+  }
+}
+
+export default async function RootLayout({children}: RootLayoutProps) {
   const locale = detectRequestLocale();
   const messages = getMessages(locale);
   const t = getTranslator(locale) as any;
   const dir = locale === 'ar' ? 'rtl' : 'ltr';
+  const currentUser = await getCurrentUser();
+  const isAuthenticated = Boolean(currentUser);
 
   return (
     <html lang={locale} dir={dir}>
@@ -28,10 +65,22 @@ export default function RootLayout({children}: RootLayoutProps) {
         <IntlProvider locale={locale} messages={messages}>
           <header style={{ padding: '1.5rem 1rem', borderBottom: '1px solid #e5e7eb', backgroundColor: '#ffffff' }}>
             <main style={{ padding: 0, maxWidth: '960px', margin: '0 auto' }}>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                <Link href="/seasons" style={{ fontSize: '1.75rem', fontWeight: 700 }}>
-                  {t('layout.appName')}
-                </Link>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem' }}>
+                  <Link href="/seasons" style={{ fontSize: '1.75rem', fontWeight: 700 }}>
+                    {t('layout.appName')}
+                  </Link>
+                  {isAuthenticated ? (
+                    <nav style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+                      <Link href="/dashboard" className="nav-link">
+                        {t('layout.nav.dashboard')}
+                      </Link>
+                      <Link href="/logout" className="nav-link" prefetch={false}>
+                        {t('layout.nav.logout')}
+                      </Link>
+                    </nav>
+                  ) : null}
+                </div>
                 <span style={{ color: '#6b7280' }}>{t('layout.tagline')}</span>
               </div>
             </main>

--- a/web/app/payment/return/route.ts
+++ b/web/app/payment/return/route.ts
@@ -1,0 +1,46 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const status = request.nextUrl.searchParams.get('status');
+  const providerRef =
+    request.nextUrl.searchParams.get('providerRef') ?? request.nextUrl.searchParams.get('provider_ref');
+
+  const details: string[] = [];
+  if (status) {
+    details.push(`Status: ${status}`);
+  }
+  if (providerRef) {
+    details.push(`Reference: ${providerRef}`);
+  }
+
+  const info = details.length ? `<p style="margin:0.5rem 0 0; color:#6b7280;">${details.join(' · ')}</p>` : '';
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charSet="utf-8" />
+    <title>Payment return</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body { font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f9fafb; margin: 0; padding: 2rem; }
+      main { max-width: 480px; margin: 4rem auto; background: white; border-radius: 1rem; padding: 2rem; box-shadow: 0 10px 20px -15px rgba(15, 23, 42, 0.45); border: 1px solid rgba(15, 23, 42, 0.05); text-align: center; }
+      a.button { display: inline-flex; align-items: center; justify-content: center; background: #2563eb; color: white; padding: 0.75rem 1.5rem; border-radius: 0.75rem; font-weight: 600; margin-top: 1.5rem; text-decoration: none; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin-top:0">We are verifying your payment…</h1>
+      <p style="color:#4b5563; margin-bottom:1rem;">You can return to your dashboard while we confirm the payment status.</p>
+      ${info}
+      <a class="button" href="/dashboard">Go to dashboard</a>
+    </main>
+  </body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: 200,
+    headers: {
+      'content-type': 'text/html; charset=utf-8'
+    }
+  });
+}

--- a/web/lib/server/api.ts
+++ b/web/lib/server/api.ts
@@ -1,0 +1,48 @@
+import {cookies} from 'next/headers';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '') ?? '';
+
+export function getAccessToken(): string | undefined {
+  const cookieStore = cookies();
+  return (
+    cookieStore.get('accessToken')?.value ??
+    cookieStore.get('token')?.value ??
+    cookieStore.get('authToken')?.value
+  );
+}
+
+export async function authorizedFetch(path: string, init?: RequestInit): Promise<Response> {
+  if (!API_BASE_URL) {
+    return new Response('API base URL is not configured', { status: 500 });
+  }
+
+  const token = getAccessToken();
+  const headers = new Headers(init?.headers);
+
+  headers.set('Content-Type', 'application/json');
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers,
+    cache: 'no-store',
+    next: { revalidate: 0 }
+  });
+
+  return response;
+}
+
+export async function fetchCurrentUser<T = unknown>(): Promise<T | null> {
+  const response = await authorizedFetch('/me', { method: 'GET' });
+  if (!response.ok) {
+    return null;
+  }
+
+  try {
+    return (await response.json()) as T;
+  } catch (error) {
+    return null;
+  }
+}

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -1,7 +1,11 @@
 {
   "layout": {
     "appName": "كتالوج إيروها",
-    "tagline": "برامج اللغة اليابانية الموسمية"
+    "tagline": "برامج اللغة اليابانية الموسمية",
+    "nav": {
+      "dashboard": "لوحة التحكم",
+      "logout": "تسجيل الخروج"
+    }
   },
   "actions": {
     "browseCourses": "تصفح الدورات",
@@ -49,6 +53,31 @@
     "schedule": "{weekday} · {start} – {end}",
     "instructor": "المدرس: {name}",
     "unassignedInstructor": "سيتم تحديد المدرس لاحقًا"
+  },
+  "enrollPage": {
+    "title": "التسجيل في {title}",
+    "price": "رسوم الدورة: {price}",
+    "submit": "المتابعة إلى الدفع",
+    "loading": "جاري الإرسال...",
+    "sectionLabel": "الشعبة المفضلة",
+    "sectionPlaceholder": "اختر شعبة",
+    "noSections": "لا حاجة لاختيار شعبة.",
+    "optional": "اختياري",
+    "waitlistedTitle": "تم إضافتك إلى قائمة الانتظار",
+    "waitlistedDescription": "سنبلغك فور توفر مقعد.",
+    "waitlistedSeats": "المقاعد المتبقية: {count}",
+    "dashboardCta": "الانتقال إلى لوحة التحكم",
+    "successToast": "تم إرسال طلب التسجيل",
+    "errorToast": "تعذر معالجة التسجيل. حاول مرة أخرى."
+  },
+  "checkoutPage": {
+    "title": "أكمل عملية الدفع",
+    "description": "افتح صفحة الدفع لإتمام تسجيلك.",
+    "openCheckout": "فتح صفحة الدفع",
+    "missingUrl": "تعذر إنشاء رابط الدفع. يرجى التواصل مع الدعم.",
+    "providerRef": "المرجع: {ref}",
+    "dashboardCta": "العودة إلى لوحة التحكم",
+    "error": "تعذر تحميل جلسة الدفع. حاول مرة أخرى."
   },
   "weekdays": {
     "0": "الأحد",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1,7 +1,11 @@
 {
   "layout": {
     "appName": "Iroha Catalog",
-    "tagline": "Seasonal Japanese language programs"
+    "tagline": "Seasonal Japanese language programs",
+    "nav": {
+      "dashboard": "Dashboard",
+      "logout": "Logout"
+    }
   },
   "actions": {
     "browseCourses": "Browse courses",
@@ -49,6 +53,31 @@
     "schedule": "{weekday} · {start} – {end}",
     "instructor": "Instructor: {name}",
     "unassignedInstructor": "Instructor TBA"
+  },
+  "enrollPage": {
+    "title": "Enroll in {title}",
+    "price": "Course tuition: {price}",
+    "submit": "Continue to payment",
+    "loading": "Submitting…",
+    "sectionLabel": "Preferred section",
+    "sectionPlaceholder": "Select a section",
+    "noSections": "No section selection is required.",
+    "optional": "optional",
+    "waitlistedTitle": "You're on the waitlist",
+    "waitlistedDescription": "We'll notify you as soon as a seat opens up.",
+    "waitlistedSeats": "Seats remaining: {count}",
+    "dashboardCta": "Go to dashboard",
+    "successToast": "Enrollment submitted",
+    "errorToast": "We couldn't process your enrollment. Please try again."
+  },
+  "checkoutPage": {
+    "title": "Complete your payment",
+    "description": "Open the checkout page to finalize your enrollment.",
+    "openCheckout": "Open checkout",
+    "missingUrl": "We couldn't generate a checkout link. Please contact support.",
+    "providerRef": "Reference: {ref}",
+    "dashboardCta": "Return to dashboard",
+    "error": "We couldn't load your checkout session. Please try again."
   },
   "weekdays": {
     "0": "Sunday",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1,7 +1,11 @@
 {
   "layout": {
     "appName": "いろはカタログ",
-    "tagline": "季節制の日本語プログラム"
+    "tagline": "季節制の日本語プログラム",
+    "nav": {
+      "dashboard": "ダッシュボード",
+      "logout": "ログアウト"
+    }
   },
   "actions": {
     "browseCourses": "講座を探す",
@@ -49,6 +53,31 @@
     "schedule": "{weekday} · {start} 〜 {end}",
     "instructor": "担当講師: {name}",
     "unassignedInstructor": "担当講師: 調整中"
+  },
+  "enrollPage": {
+    "title": "{title} に申し込む",
+    "price": "受講料: {price}",
+    "submit": "支払いに進む",
+    "loading": "送信中...",
+    "sectionLabel": "希望クラス",
+    "sectionPlaceholder": "クラスを選択",
+    "noSections": "クラスの選択は不要です。",
+    "optional": "任意",
+    "waitlistedTitle": "ウェイティングリストに登録されました",
+    "waitlistedDescription": "席が空き次第ご連絡いたします。",
+    "waitlistedSeats": "残席: {count}",
+    "dashboardCta": "ダッシュボードへ戻る",
+    "successToast": "申込を送信しました",
+    "errorToast": "申込を処理できませんでした。もう一度お試しください。"
+  },
+  "checkoutPage": {
+    "title": "支払いを完了する",
+    "description": "チェックアウトページを開いて申し込みを確定してください。",
+    "openCheckout": "チェックアウトを開く",
+    "missingUrl": "チェックアウトリンクを生成できませんでした。サポートへお問い合わせください。",
+    "providerRef": "参照番号: {ref}",
+    "dashboardCta": "ダッシュボードに戻る",
+    "error": "チェックアウトの読み込みに失敗しました。もう一度お試しください。"
   },
   "weekdays": {
     "0": "日曜",

--- a/web/types/api.ts
+++ b/web/types/api.ts
@@ -1,0 +1,27 @@
+export type EnrollmentStatus =
+  | 'pending'
+  | 'active'
+  | 'waitlisted'
+  | 'cancelled'
+  | 'completed';
+
+export interface EnrollResponse {
+  enrollmentId: string;
+  status: EnrollmentStatus;
+  seatsLeft?: number | null;
+  seats_left?: number | null;
+}
+
+export interface PaymentIntentResponse {
+  checkoutUrl?: string | null;
+  providerRef?: string | null;
+  provider?: string | null;
+}
+
+export interface CurrentUserResponse {
+  id: string;
+  email: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  roles?: string[];
+}


### PR DESCRIPTION
## Summary
- add API route handlers that proxy enrollment creation, payment intents, and auth lookups using the backend token
- introduce typed API helpers plus checkout and enrollment pages with waitlist messaging and toast UX
- render a payment return page, enhance the navbar for signed-in users, and document the required payment return URL env var

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4a6f08c8c832f892431ba5154c519