### PR TITLE
feat(web): add student dashboard with auth proxies

### DIFF
--- a/web/app/api/attendance/mine/route.ts
+++ b/web/app/api/attendance/mine/route.ts
@@ -1,0 +1,58 @@
+import {cookies} from 'next/headers';
+import {NextRequest, NextResponse} from 'next/server';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '');
+
+function getAccessToken(): string | null {
+  return cookies().get('accessToken')?.value ?? null;
+}
+
+function buildHeaders(token: string): Headers {
+  const headers = new Headers();
+  headers.set('Accept', 'application/json');
+  headers.set('Authorization', `Bearer ${token}`);
+  return headers;
+}
+
+export async function GET(request: NextRequest) {
+  if (!API_BASE_URL) {
+    return NextResponse.json({ message: 'API base URL is not configured' }, { status: 500 });
+  }
+
+  const token = getAccessToken();
+  if (!token) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  const {searchParams} = new URL(request.url);
+  const courseId = searchParams.get('courseId');
+
+  if (!courseId) {
+    return NextResponse.json({ message: 'courseId is required' }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/attendance/mine?courseId=${encodeURIComponent(courseId)}`, {
+      method: 'GET',
+      headers: buildHeaders(token),
+      cache: 'no-store',
+      next: { revalidate: 0 }
+    });
+
+    if (response.status === 404) {
+      return NextResponse.json({ present: 0, total: 0 }, { status: 200 });
+    }
+
+    const contentType = response.headers.get('content-type') ?? 'application/json';
+    const body = await response.text();
+
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        'content-type': contentType
+      }
+    });
+  } catch (error) {
+    return NextResponse.json({ message: 'Failed to reach attendance service' }, { status: 502 });
+  }
+}

--- a/web/app/api/certificates/route.ts
+++ b/web/app/api/certificates/route.ts
@@ -1,0 +1,58 @@
+import {cookies} from 'next/headers';
+import {NextRequest, NextResponse} from 'next/server';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '');
+
+function getAccessToken(): string | null {
+  return cookies().get('accessToken')?.value ?? null;
+}
+
+function buildHeaders(token: string): Headers {
+  const headers = new Headers();
+  headers.set('Accept', 'application/json');
+  headers.set('Authorization', `Bearer ${token}`);
+  return headers;
+}
+
+export async function GET(request: NextRequest) {
+  if (!API_BASE_URL) {
+    return NextResponse.json({ message: 'API base URL is not configured' }, { status: 500 });
+  }
+
+  const token = getAccessToken();
+  if (!token) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  const {searchParams} = new URL(request.url);
+  const enrollmentId = searchParams.get('enrollmentId');
+
+  if (!enrollmentId) {
+    return NextResponse.json({ message: 'enrollmentId is required' }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/certificates?enrollmentId=${encodeURIComponent(enrollmentId)}`, {
+      method: 'GET',
+      headers: buildHeaders(token),
+      cache: 'no-store',
+      next: { revalidate: 0 }
+    });
+
+    if (response.status === 404) {
+      return NextResponse.json([], { status: 200 });
+    }
+
+    const contentType = response.headers.get('content-type') ?? 'application/json';
+    const body = await response.text();
+
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        'content-type': contentType
+      }
+    });
+  } catch (error) {
+    return NextResponse.json({ message: 'Failed to reach certificates service' }, { status: 502 });
+  }
+}

--- a/web/app/api/enrollments/mine/route.ts
+++ b/web/app/api/enrollments/mine/route.ts
@@ -1,0 +1,47 @@
+import {cookies} from 'next/headers';
+import {NextRequest, NextResponse} from 'next/server';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '');
+
+function getAccessToken(): string | null {
+  return cookies().get('accessToken')?.value ?? null;
+}
+
+function buildHeaders(token: string): Headers {
+  const headers = new Headers();
+  headers.set('Accept', 'application/json');
+  headers.set('Authorization', `Bearer ${token}`);
+  return headers;
+}
+
+export async function GET(_request: NextRequest) {
+  if (!API_BASE_URL) {
+    return NextResponse.json({ message: 'API base URL is not configured' }, { status: 500 });
+  }
+
+  const token = getAccessToken();
+  if (!token) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/enrollments/mine`, {
+      method: 'GET',
+      headers: buildHeaders(token),
+      cache: 'no-store',
+      next: { revalidate: 0 }
+    });
+
+    const contentType = response.headers.get('content-type') ?? 'application/json';
+    const body = await response.text();
+
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        'content-type': contentType
+      }
+    });
+  } catch (error) {
+    return NextResponse.json({ message: 'Failed to reach enrollment service' }, { status: 502 });
+  }
+}

--- a/web/app/api/lessons/route.ts
+++ b/web/app/api/lessons/route.ts
@@ -1,0 +1,58 @@
+import {cookies} from 'next/headers';
+import {NextRequest, NextResponse} from 'next/server';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '');
+
+function getAccessToken(): string | null {
+  return cookies().get('accessToken')?.value ?? null;
+}
+
+function buildHeaders(token: string): Headers {
+  const headers = new Headers();
+  headers.set('Accept', 'application/json');
+  headers.set('Authorization', `Bearer ${token}`);
+  return headers;
+}
+
+export async function GET(request: NextRequest) {
+  if (!API_BASE_URL) {
+    return NextResponse.json({ message: 'API base URL is not configured' }, { status: 500 });
+  }
+
+  const token = getAccessToken();
+  if (!token) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  const {searchParams} = new URL(request.url);
+  const courseId = searchParams.get('courseId');
+
+  if (!courseId) {
+    return NextResponse.json({ message: 'courseId is required' }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/lessons?courseId=${encodeURIComponent(courseId)}`, {
+      method: 'GET',
+      headers: buildHeaders(token),
+      cache: 'no-store',
+      next: { revalidate: 0 }
+    });
+
+    if (response.status === 404) {
+      return NextResponse.json([], { status: 200 });
+    }
+
+    const contentType = response.headers.get('content-type') ?? 'application/json';
+    const body = await response.text();
+
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        'content-type': contentType
+      }
+    });
+  } catch (error) {
+    return NextResponse.json({ message: 'Failed to reach lessons service' }, { status: 502 });
+  }
+}

--- a/web/app/api/quiz-attempts/route.ts
+++ b/web/app/api/quiz-attempts/route.ts
@@ -1,0 +1,58 @@
+import {cookies} from 'next/headers';
+import {NextRequest, NextResponse} from 'next/server';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '');
+
+function getAccessToken(): string | null {
+  return cookies().get('accessToken')?.value ?? null;
+}
+
+function buildHeaders(token: string): Headers {
+  const headers = new Headers();
+  headers.set('Accept', 'application/json');
+  headers.set('Authorization', `Bearer ${token}`);
+  return headers;
+}
+
+export async function GET(request: NextRequest) {
+  if (!API_BASE_URL) {
+    return NextResponse.json({ message: 'API base URL is not configured' }, { status: 500 });
+  }
+
+  const token = getAccessToken();
+  if (!token) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  const {searchParams} = new URL(request.url);
+  const courseId = searchParams.get('courseId');
+
+  if (!courseId) {
+    return NextResponse.json({ message: 'courseId is required' }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/quiz-attempts?courseId=${encodeURIComponent(courseId)}`, {
+      method: 'GET',
+      headers: buildHeaders(token),
+      cache: 'no-store',
+      next: { revalidate: 0 }
+    });
+
+    if (response.status === 404) {
+      return NextResponse.json([], { status: 200 });
+    }
+
+    const contentType = response.headers.get('content-type') ?? 'application/json';
+    const body = await response.text();
+
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        'content-type': contentType
+      }
+    });
+  } catch (error) {
+    return NextResponse.json({ message: 'Failed to reach quiz attempts service' }, { status: 502 });
+  }
+}

--- a/web/app/api/quizzes/route.ts
+++ b/web/app/api/quizzes/route.ts
@@ -1,0 +1,58 @@
+import {cookies} from 'next/headers';
+import {NextRequest, NextResponse} from 'next/server';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '');
+
+function getAccessToken(): string | null {
+  return cookies().get('accessToken')?.value ?? null;
+}
+
+function buildHeaders(token: string): Headers {
+  const headers = new Headers();
+  headers.set('Accept', 'application/json');
+  headers.set('Authorization', `Bearer ${token}`);
+  return headers;
+}
+
+export async function GET(request: NextRequest) {
+  if (!API_BASE_URL) {
+    return NextResponse.json({ message: 'API base URL is not configured' }, { status: 500 });
+  }
+
+  const token = getAccessToken();
+  if (!token) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  const {searchParams} = new URL(request.url);
+  const courseId = searchParams.get('courseId');
+
+  if (!courseId) {
+    return NextResponse.json({ message: 'courseId is required' }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/quizzes?courseId=${encodeURIComponent(courseId)}`, {
+      method: 'GET',
+      headers: buildHeaders(token),
+      cache: 'no-store',
+      next: { revalidate: 0 }
+    });
+
+    if (response.status === 404) {
+      return NextResponse.json([], { status: 200 });
+    }
+
+    const contentType = response.headers.get('content-type') ?? 'application/json';
+    const body = await response.text();
+
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        'content-type': contentType
+      }
+    });
+  } catch (error) {
+    return NextResponse.json({ message: 'Failed to reach quizzes service' }, { status: 502 });
+  }
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,0 +1,624 @@
+import {cookies, headers} from 'next/headers';
+import Link from 'next/link';
+import {redirect} from 'next/navigation';
+
+import AttendanceSummary, {AttendanceSnapshot} from '@/components/attendance-summary';
+import Certificates, {CertificateSummary} from '@/components/certificates';
+import LessonCard, {LessonSummary} from '@/components/lesson-card';
+import QuizList, {QuizSummary} from '@/components/quiz-list';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+import {getSession} from '@/lib/server-auth';
+
+export const dynamic = 'force-dynamic';
+
+type EnrollmentRecord = {
+  id: string;
+  status?: string | null;
+  courseId?: string | null;
+  courseTitle?: string | null;
+  seatsLeft?: number | null;
+  raw: any;
+};
+
+type LessonRecord = {
+  id: string;
+  title?: string | null;
+  releaseAt?: Date | null;
+  videoUrl?: string | null;
+};
+
+type QuizRecord = {
+  id: string;
+  title?: string | null;
+  dueAt?: Date | null;
+  startUrl?: string | null;
+};
+
+type AttemptRecord = {
+  id: string;
+  quizId?: string | null;
+  status?: string | null;
+  submittedAt?: Date | null;
+};
+
+type AttendanceRecord = {
+  presentCount?: number | null;
+  totalCount?: number | null;
+  percentage?: number | null;
+  status?: string | null;
+};
+
+type CertificateRecord = {
+  id: string;
+  title?: string | null;
+  courseTitle?: string | null;
+  url?: string | null;
+};
+
+type CourseContext = {
+  enrollment: EnrollmentRecord;
+  lessons: LessonRecord[];
+  quizzes: QuizRecord[];
+  attempts: AttemptRecord[];
+  attendance: AttendanceRecord | null;
+  certificates: CertificateRecord[];
+};
+
+function toArray(payload: unknown): any[] {
+  if (Array.isArray(payload)) return payload;
+  if (payload && typeof payload === 'object') {
+    const container = payload as Record<string, unknown>;
+    for (const key of ['data', 'items', 'results', 'records']) {
+      const value = container[key];
+      if (Array.isArray(value)) {
+        return value;
+      }
+    }
+  }
+  return [];
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function toDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  const date = new Date(value as string);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function normaliseStatus(status: unknown): string | null {
+  if (typeof status !== 'string') return null;
+  return status;
+}
+
+function normaliseCourseTitle(enrollment: any): string | null {
+  if (!enrollment) return null;
+  return (
+    enrollment.courseTitle ??
+    enrollment.course_title ??
+    enrollment.course?.title ??
+    enrollment.title ??
+    null
+  );
+}
+
+function mapEnrollment(raw: any): EnrollmentRecord | null {
+  if (!raw) return null;
+  const idCandidate = raw.id ?? raw.enrollment_id ?? raw.enrollmentId ?? raw.uuid ?? raw.course_id ?? raw.courseId;
+  if (!idCandidate) {
+    return null;
+  }
+
+  const courseId = raw.courseId ?? raw.course_id ?? raw.course?.id ?? raw.course?.course_id ?? null;
+  const seatsLeft =
+    toNumber(raw.seats_left ?? raw.seatsLeft ?? raw.course?.seats_left ?? raw.course?.seatsLeft ?? null) ?? null;
+
+  return {
+    id: String(idCandidate),
+    status: normaliseStatus(raw.status ?? raw.state ?? raw.progress ?? null),
+    courseId: courseId ? String(courseId) : null,
+    courseTitle: normaliseCourseTitle(raw),
+    seatsLeft,
+    raw
+  };
+}
+
+function mapLesson(raw: any): LessonRecord | null {
+  if (!raw) return null;
+  const id = raw.id ?? raw.lesson_id ?? raw.lessonId ?? raw.slug ?? raw.uuid ?? raw.title;
+  if (!id) {
+    return null;
+  }
+  const releaseAt =
+    toDate(
+      raw.releaseAt ??
+        raw.release_at ??
+        raw.availableAt ??
+        raw.available_at ??
+        raw.startAt ??
+        raw.start_at ??
+        raw.scheduled_at ??
+        raw.published_at
+    ) ?? null;
+
+  return {
+    id: String(id),
+    title: raw.title ?? raw.name ?? null,
+    releaseAt,
+    videoUrl: raw.videoUrl ?? raw.video_url ?? raw.video ?? raw.resourceUrl ?? raw.resource_url ?? raw.url ?? null
+  };
+}
+
+function mapQuiz(raw: any): QuizRecord | null {
+  if (!raw) return null;
+  const id = raw.id ?? raw.quiz_id ?? raw.quizId ?? raw.uuid;
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id: String(id),
+    title: raw.title ?? raw.name ?? null,
+    dueAt: toDate(raw.dueAt ?? raw.due_at ?? raw.deadline ?? raw.closesAt ?? raw.closes_at ?? raw.available_until),
+    startUrl: raw.launchUrl ?? raw.launch_url ?? raw.startUrl ?? raw.start_url ?? raw.url ?? null
+  };
+}
+
+function mapAttempt(raw: any): AttemptRecord | null {
+  if (!raw) return null;
+  const id = raw.id ?? raw.attempt_id ?? raw.attemptId ?? `${raw.quiz_id ?? raw.quizId ?? 'attempt'}-${raw.userId ?? raw.user_id ?? ''}`;
+  return {
+    id: String(id),
+    quizId: raw.quizId ? String(raw.quizId) : raw.quiz_id ? String(raw.quiz_id) : raw.quiz?.id ? String(raw.quiz.id) : null,
+    status: normaliseStatus(raw.status ?? raw.state ?? null),
+    submittedAt: toDate(
+      raw.submittedAt ?? raw.submitted_at ?? raw.completedAt ?? raw.completed_at ?? raw.finishedAt ?? raw.finished_at
+    )
+  };
+}
+
+function mapAttendance(raw: any): AttendanceRecord | null {
+  if (!raw) return null;
+
+  if (Array.isArray(raw)) {
+    const total = raw.length;
+    if (total === 0) {
+      return { presentCount: 0, totalCount: 0, percentage: null, status: null };
+    }
+    const present = raw.filter((entry) => {
+      const status = (entry?.status ?? entry?.attendanceStatus ?? entry?.state ?? '').toLowerCase();
+      return status === 'present' || status === 'attended' || status === 'complete';
+    }).length;
+    const percentage = total > 0 ? (present / total) * 100 : null;
+    return { presentCount: present, totalCount: total, percentage, status: null };
+  }
+
+  const present =
+    toNumber(
+      raw.present ?? raw.presentCount ?? raw.attended ?? raw.attendedSessions ?? raw.sessionsAttended ?? raw.completed ?? null
+    ) ?? null;
+  const total =
+    toNumber(
+      raw.total ??
+        raw.totalCount ??
+        raw.sessions ??
+        raw.totalSessions ??
+        raw.requiredSessions ??
+        raw.total_classes ??
+        raw.expected ??
+        raw.overall?.total ??
+        null
+    ) ?? null;
+  const percentage =
+    toNumber(raw.percentage ?? raw.percent ?? raw.attendancePercentage ?? raw.rate ?? null) ??
+    (present !== null && total ? (present / total) * 100 : null);
+
+  return {
+    presentCount: present,
+    totalCount: total,
+    percentage,
+    status: raw.status ?? raw.attendanceStatus ?? raw.summary ?? null
+  };
+}
+
+function mapCertificate(raw: any): CertificateRecord | null {
+  if (!raw) return null;
+  const id = raw.id ?? raw.certificate_id ?? raw.certificateId ?? raw.uuid ?? raw.slug;
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id: String(id),
+    title: raw.title ?? raw.name ?? raw.label ?? null,
+    courseTitle: raw.course?.title ?? raw.courseTitle ?? raw.course_title ?? null,
+    url: raw.pdfUrl ?? raw.pdf_url ?? raw.url ?? raw.downloadUrl ?? raw.download_url ?? null
+  };
+}
+
+function pickCourseTitle(enrollment: EnrollmentRecord): string | null {
+  return enrollment.courseTitle ?? enrollment.raw?.course?.title ?? null;
+}
+
+function computeNextLesson(contexts: CourseContext[]): LessonSummary | null {
+  const now = Date.now();
+  const candidates: Array<LessonSummary & { releaseTime?: number | null }> = [];
+
+  contexts.forEach((context) => {
+    const lessons = context.lessons;
+    if (!lessons || lessons.length === 0) {
+      return;
+    }
+
+    const sortedByDate = lessons
+      .map((lesson) => ({
+        ...lesson,
+        releaseTime: lesson.releaseAt ? lesson.releaseAt.getTime() : null
+      }))
+      .sort((a, b) => {
+        const aTime = a.releaseTime ?? Number.MAX_SAFE_INTEGER;
+        const bTime = b.releaseTime ?? Number.MAX_SAFE_INTEGER;
+        return aTime - bTime;
+      });
+
+    const upcoming = sortedByDate.filter((lesson) => typeof lesson.releaseTime === 'number' && lesson.releaseTime > now);
+    const fallback = sortedByDate.filter((lesson) => typeof lesson.releaseTime === 'number' && lesson.releaseTime <= now);
+
+    const selected = upcoming.length > 0 ? upcoming[0] : fallback.length > 0 ? fallback[fallback.length - 1] : sortedByDate[0];
+
+    if (selected) {
+      candidates.push({
+        courseTitle: pickCourseTitle(context.enrollment),
+        lessonTitle: selected.title ?? null,
+        releaseAt: selected.releaseAt ?? null,
+        videoUrl: selected.videoUrl ?? null,
+        releaseTime: selected.releaseTime ?? null
+      });
+    }
+  });
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  candidates.sort((a, b) => {
+    const aTime = typeof a.releaseTime === 'number' ? a.releaseTime : Number.MAX_SAFE_INTEGER;
+    const bTime = typeof b.releaseTime === 'number' ? b.releaseTime : Number.MAX_SAFE_INTEGER;
+    return aTime - bTime;
+  });
+
+  const best = candidates[0];
+  return {
+    courseTitle: best.courseTitle ?? null,
+    lessonTitle: best.lessonTitle ?? null,
+    releaseAt: best.releaseAt ?? null,
+    videoUrl: best.videoUrl ?? null
+  };
+}
+
+function computeDueQuizzes(contexts: CourseContext[]): QuizSummary[] {
+  const now = Date.now();
+  const items: QuizSummary[] = [];
+
+  contexts.forEach((context) => {
+    const attemptsByQuiz = new Map<string, AttemptRecord[]>();
+    context.attempts.forEach((attempt) => {
+      if (!attempt.quizId) return;
+      const key = String(attempt.quizId);
+      const entries = attemptsByQuiz.get(key) ?? [];
+      entries.push(attempt);
+      attemptsByQuiz.set(key, entries);
+    });
+
+    context.quizzes.forEach((quiz) => {
+      if (!quiz.dueAt) return;
+      const dueTime = quiz.dueAt.getTime();
+      if (Number.isNaN(dueTime) || dueTime < now) {
+        return;
+      }
+
+      const quizAttempts = attemptsByQuiz.get(String(quiz.id)) ?? [];
+      const hasSubmitted = quizAttempts.some((attempt) => {
+        const status = attempt.status?.toLowerCase() ?? '';
+        if (status === 'submitted' || status === 'completed' || status === 'passed') {
+          return true;
+        }
+        return Boolean(attempt.submittedAt);
+      });
+
+      if (hasSubmitted) {
+        return;
+      }
+
+      items.push({
+        id: quiz.id,
+        title: quiz.title ?? null,
+        dueAt: quiz.dueAt ?? null,
+        startUrl: quiz.startUrl ?? null,
+        courseTitle: pickCourseTitle(context.enrollment)
+      });
+    });
+  });
+
+  items.sort((a, b) => {
+    const aTime = a.dueAt ? a.dueAt.getTime() : Number.MAX_SAFE_INTEGER;
+    const bTime = b.dueAt ? b.dueAt.getTime() : Number.MAX_SAFE_INTEGER;
+    return aTime - bTime;
+  });
+
+  return items;
+}
+
+function computeAttendanceSnapshot(contexts: CourseContext[]): AttendanceSnapshot {
+  let presentTotal = 0;
+  let sessionTotal = 0;
+  let primaryStatus: string | null = null;
+
+  contexts.forEach((context) => {
+    const attendance = context.attendance;
+    if (!attendance) return;
+    if (typeof attendance.presentCount === 'number') {
+      presentTotal += attendance.presentCount;
+    }
+    if (typeof attendance.totalCount === 'number') {
+      sessionTotal += attendance.totalCount;
+    }
+    if (!primaryStatus && attendance.status) {
+      primaryStatus = attendance.status;
+    }
+  });
+
+  if (sessionTotal === 0) {
+    return { percentage: null, presentCount: null, totalCount: null, status: primaryStatus };
+  }
+
+  const percentage = (presentTotal / sessionTotal) * 100;
+  return {
+    percentage,
+    presentCount: presentTotal,
+    totalCount: sessionTotal,
+    status: primaryStatus
+  };
+}
+
+function computeCertificates(contexts: CourseContext[]): CertificateSummary[] {
+  const certificates: CertificateSummary[] = [];
+  contexts.forEach((context) => {
+    context.certificates.forEach((certificate) => {
+      certificates.push({
+        id: certificate.id,
+        title: certificate.title ?? null,
+        courseTitle: certificate.courseTitle ?? pickCourseTitle(context.enrollment),
+        url: certificate.url ?? null
+      });
+    });
+  });
+  return certificates;
+}
+
+function formatStatusLabel(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return value
+    .split(/[\s_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+export default async function DashboardPage() {
+  const session = getSession();
+  if (!session.accessToken) {
+    redirect('/auth/login');
+  }
+
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+  const headersList = headers();
+  const cookieStore = cookies();
+
+  const host = headersList.get('x-forwarded-host') ?? headersList.get('host');
+  const protocol = headersList.get('x-forwarded-proto') ?? (host && host.includes('localhost') ? 'http' : 'https');
+  const baseUrl = host ? `${protocol}://${host}` : null;
+  const cookieHeader = cookieStore
+    .getAll()
+    .map(({name, value}) => `${name}=${value}`)
+    .join('; ');
+
+  const fetchJson = async <T,>(path: string): Promise<T | null> => {
+    if (!baseUrl) return null;
+    try {
+      const response = await fetch(`${baseUrl}${path}`, {
+        method: 'GET',
+        headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+        cache: 'no-store',
+        next: { revalidate: 0 }
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const contentType = response.headers.get('content-type') ?? '';
+      if (contentType.includes('application/json')) {
+        return (await response.json()) as T;
+      }
+
+      const text = await response.text();
+      if (!text) {
+        return null;
+      }
+
+      try {
+        return JSON.parse(text) as T;
+      } catch (error) {
+        return null;
+      }
+    } catch (error) {
+      return null;
+    }
+  };
+
+  const enrollmentsPayload = await fetchJson<any>('/api/enrollments/mine');
+  const enrollmentItems = toArray(enrollmentsPayload ?? []);
+  const enrollments = enrollmentItems
+    .map((item) => mapEnrollment(item))
+    .filter((item): item is EnrollmentRecord => Boolean(item));
+  const enrollmentError = !enrollmentsPayload && enrollments.length === 0;
+
+  const activeEnrollments = enrollments.filter((enrollment) => {
+    const status = enrollment.status?.toLowerCase();
+    return status === 'active' || status === 'in_progress' || status === 'enrolled';
+  });
+
+  const contexts: CourseContext[] = await Promise.all(
+    activeEnrollments.map(async (enrollment) => {
+      if (!enrollment.courseId) {
+        return {
+          enrollment,
+          lessons: [],
+          quizzes: [],
+          attempts: [],
+          attendance: null,
+          certificates: []
+        };
+      }
+
+      const courseIdParam = encodeURIComponent(enrollment.courseId);
+      const [lessonsPayload, quizzesPayload, attemptsPayload, attendancePayload, certificatesPayload] = await Promise.all([
+        fetchJson<any>(`/api/lessons?courseId=${courseIdParam}`),
+        fetchJson<any>(`/api/quizzes?courseId=${courseIdParam}`),
+        fetchJson<any>(`/api/quiz-attempts?courseId=${courseIdParam}`),
+        fetchJson<any>(`/api/attendance/mine?courseId=${courseIdParam}`),
+        fetchJson<any>(`/api/certificates?enrollmentId=${encodeURIComponent(enrollment.id)}`)
+      ]);
+
+      const lessons = toArray(lessonsPayload ?? []).map((lesson) => mapLesson(lesson)).filter((lesson): lesson is LessonRecord => Boolean(lesson));
+      const quizzes = toArray(quizzesPayload ?? []).map((quiz) => mapQuiz(quiz)).filter((quiz): quiz is QuizRecord => Boolean(quiz));
+      const attempts = toArray(attemptsPayload ?? []).map((attempt) => mapAttempt(attempt)).filter((attempt): attempt is AttemptRecord => Boolean(attempt));
+      const attendance = mapAttendance(attendancePayload);
+      const certificates = toArray(certificatesPayload ?? [])
+        .map((certificate) => mapCertificate(certificate))
+        .filter((certificate): certificate is CertificateRecord => Boolean(certificate));
+
+      return {
+        enrollment,
+        lessons,
+        quizzes,
+        attempts,
+        attendance,
+        certificates
+      };
+    })
+  );
+
+  const nextLesson = computeNextLesson(contexts);
+  const dueQuizzes = computeDueQuizzes(contexts);
+  const attendanceSnapshotRaw = computeAttendanceSnapshot(contexts);
+  const certificates = computeCertificates(contexts);
+
+  let attendanceStatusLabel = attendanceSnapshotRaw.status ?? null;
+  if (attendanceSnapshotRaw.percentage !== null && attendanceSnapshotRaw.percentage !== undefined) {
+    const percentage = attendanceSnapshotRaw.percentage;
+    const statusKey = percentage >= 85 ? 'great' : percentage >= 60 ? 'warning' : 'danger';
+    attendanceStatusLabel = t(`dashboard.attendanceStatus.${statusKey}`);
+  }
+
+  const attendanceSnapshot: AttendanceSnapshot = {
+    percentage: attendanceSnapshotRaw.percentage,
+    presentCount: attendanceSnapshotRaw.presentCount ?? null,
+    totalCount: attendanceSnapshotRaw.totalCount ?? null,
+    status: attendanceStatusLabel
+  };
+
+  const hasGlobalError = !baseUrl || enrollmentError;
+
+  return (
+    <section className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold text-slate-900">{t('dashboard.title')}</h1>
+        <p className="text-sm text-slate-600">{t('dashboard.description')}</p>
+      </header>
+
+      {hasGlobalError ? <div className="error-state">{t('errors.generic')}</div> : null}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3">
+        <LessonCard
+          heading={t('dashboard.nextLesson')}
+          lesson={nextLesson}
+          locale={locale}
+          actionLabel={t('dashboard.openLesson')}
+          emptyMessage={t('dashboard.nextLessonEmpty')}
+        />
+
+        <QuizList
+          heading={t('dashboard.dueQuizzes')}
+          quizzes={dueQuizzes}
+          locale={locale}
+          actionLabel={t('dashboard.startQuiz')}
+          emptyMessage={t('dashboard.dueQuizzesEmpty')}
+        />
+
+        <AttendanceSummary
+          heading={t('dashboard.attendance')}
+          snapshot={attendanceSnapshot}
+          emptyMessage={t('dashboard.attendanceEmpty')}
+        />
+
+        <Certificates
+          heading={t('dashboard.certificates')}
+          certificates={certificates}
+          actionLabel={t('dashboard.viewCertificate')}
+          emptyMessage={t('dashboard.certificatesEmpty')}
+        />
+
+        <article className="card rounded-2xl border border-slate-200 bg-white p-6 shadow-sm flex flex-col gap-4 md:col-span-2 xl:col-span-3">
+          <header className="flex items-center justify-between gap-2">
+            <h2 className="text-lg font-semibold text-slate-900">{t('dashboard.enrollments')}</h2>
+            <Link href="/courses" className="text-sm font-semibold text-blue-600 hover:text-blue-500">
+              {t('actions.browseCourses')}
+            </Link>
+          </header>
+
+          {enrollments.length === 0 ? (
+            <p className="text-sm text-slate-500">{t('dashboard.enrollmentsEmpty')}</p>
+          ) : (
+            <ul className="flex flex-col gap-3">
+              {enrollments.map((enrollment) => {
+                const statusLabel = formatStatusLabel(enrollment.status);
+                return (
+                  <li key={enrollment.id} className="flex flex-col gap-1 rounded-lg border border-slate-100 bg-slate-50/80 p-4">
+                    <span className="text-base font-semibold text-slate-800">{pickCourseTitle(enrollment) ?? t('dashboard.untitledCourse')}</span>
+                    <div className="flex flex-wrap items-center gap-4 text-xs text-slate-500">
+                      {statusLabel ? (
+                        <span>
+                          {t('dashboard.statusLabel')}: <strong className="font-semibold text-slate-700">{statusLabel}</strong>
+                        </span>
+                      ) : null}
+                      {typeof enrollment.seatsLeft === 'number' ? (
+                        <span>
+                          {t('dashboard.seatsLabel')}: <strong className="font-semibold text-slate-700">{enrollment.seatsLeft}</strong>
+                        </span>
+                      ) : null}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/web/components/attendance-summary.tsx
+++ b/web/components/attendance-summary.tsx
@@ -1,0 +1,49 @@
+export type AttendanceSnapshot = {
+  percentage: number | null;
+  presentCount?: number | null;
+  totalCount?: number | null;
+  status?: string | null;
+};
+
+type AttendanceSummaryProps = {
+  heading: string;
+  snapshot?: AttendanceSnapshot | null;
+  emptyMessage: string;
+};
+
+function formatPercentage(value: number | null | undefined): string | null {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+
+  const bounded = Math.max(0, Math.min(100, value));
+  return `${Math.round(bounded)}%`;
+}
+
+export function AttendanceSummary({ heading, snapshot, emptyMessage }: AttendanceSummaryProps) {
+  const percentLabel = formatPercentage(snapshot?.percentage ?? null);
+  const hasData = typeof snapshot?.presentCount === 'number' && typeof snapshot?.totalCount === 'number' && snapshot.totalCount > 0;
+
+  return (
+    <article className="card rounded-2xl border border-slate-200 bg-white p-6 shadow-sm flex flex-col gap-4">
+      <header>
+        <h2 className="text-lg font-semibold text-slate-900">{heading}</h2>
+      </header>
+
+      {percentLabel ? (
+        <div className="flex flex-col gap-2">
+          <span className="text-3xl font-bold text-blue-600">{percentLabel}</span>
+          {snapshot?.status ? <span className="text-sm text-slate-500">{snapshot.status}</span> : null}
+        </div>
+      ) : (
+        <p className="text-sm text-slate-500">{emptyMessage}</p>
+      )}
+
+      {hasData ? (
+        <p className="text-xs text-slate-500">{snapshot?.presentCount} / {snapshot?.totalCount}</p>
+      ) : null}
+    </article>
+  );
+}
+
+export default AttendanceSummary;

--- a/web/components/certificates.tsx
+++ b/web/components/certificates.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+
+export type CertificateSummary = {
+  id: string;
+  title?: string | null;
+  courseTitle?: string | null;
+  url?: string | null;
+};
+
+type CertificatesProps = {
+  heading: string;
+  certificates: CertificateSummary[];
+  emptyMessage: string;
+  actionLabel: string;
+};
+
+export function Certificates({ heading, certificates, emptyMessage, actionLabel }: CertificatesProps) {
+  return (
+    <article className="card rounded-2xl border border-slate-200 bg-white p-6 shadow-sm flex flex-col gap-4">
+      <header>
+        <h2 className="text-lg font-semibold text-slate-900">{heading}</h2>
+      </header>
+
+      {certificates.length === 0 ? (
+        <p className="text-sm text-slate-500">{emptyMessage}</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {certificates.map((certificate) => (
+            <li key={certificate.id} className="flex items-center justify-between gap-3 rounded-lg border border-slate-100 bg-slate-50/80 p-3">
+              <div className="flex flex-col">
+                <span className="text-sm font-semibold text-slate-800">{certificate.title ?? 'Certificate'}</span>
+                {certificate.courseTitle ? (
+                  <span className="text-xs text-slate-500">{certificate.courseTitle}</span>
+                ) : null}
+              </div>
+              {certificate.url ? (
+                <Link
+                  href={certificate.url}
+                  className="inline-flex h-9 items-center justify-center rounded-md bg-emerald-600 px-3 text-xs font-semibold uppercase tracking-wide text-white transition hover:bg-emerald-500"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {actionLabel}
+                </Link>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </article>
+  );
+}
+
+export default Certificates;

--- a/web/components/lesson-card.tsx
+++ b/web/components/lesson-card.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+
+export type LessonSummary = {
+  courseTitle?: string | null;
+  lessonTitle?: string | null;
+  releaseAt?: Date | string | null;
+  videoUrl?: string | null;
+};
+
+type LessonCardProps = {
+  heading: string;
+  lesson?: LessonSummary | null;
+  locale: string;
+  actionLabel: string;
+  emptyMessage: string;
+};
+
+function formatDateTime(value: LessonSummary['releaseAt'], locale: string): string | null {
+  if (!value) return null;
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(date);
+}
+
+export function LessonCard({ heading, lesson, locale, actionLabel, emptyMessage }: LessonCardProps) {
+  const formattedRelease = formatDateTime(lesson?.releaseAt ?? null, locale);
+  const hasLesson = Boolean(lesson?.lessonTitle || formattedRelease || lesson?.videoUrl);
+
+  return (
+    <article className="card rounded-2xl border border-slate-200 bg-white p-6 shadow-sm flex flex-col gap-4">
+      <header className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold text-slate-900">{heading}</h2>
+        {lesson?.courseTitle ? (
+          <span className="text-sm text-slate-500">{lesson.courseTitle}</span>
+        ) : null}
+      </header>
+
+      {hasLesson ? (
+        <div className="space-y-2">
+          {lesson?.lessonTitle ? (
+            <p className="text-base font-medium text-slate-800">{lesson.lessonTitle}</p>
+          ) : null}
+          {formattedRelease ? (
+            <p className="text-sm text-slate-500">{formattedRelease}</p>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-sm text-slate-500">{emptyMessage}</p>
+      )}
+
+      {lesson?.videoUrl ? (
+        <footer className="mt-auto">
+          <Link
+            href={lesson.videoUrl}
+            className="inline-flex h-10 items-center justify-center rounded-lg bg-blue-600 px-4 text-sm font-semibold text-white transition hover:bg-blue-500"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {actionLabel}
+          </Link>
+        </footer>
+      ) : null}
+    </article>
+  );
+}
+
+export default LessonCard;

--- a/web/components/quiz-list.tsx
+++ b/web/components/quiz-list.tsx
@@ -1,0 +1,71 @@
+import Link from 'next/link';
+
+export type QuizSummary = {
+  id: string;
+  title?: string | null;
+  dueAt?: Date | null;
+  courseTitle?: string | null;
+  startUrl?: string | null;
+};
+
+type QuizListProps = {
+  heading: string;
+  quizzes: QuizSummary[];
+  locale: string;
+  emptyMessage: string;
+  actionLabel: string;
+};
+
+function formatDate(value: QuizSummary['dueAt'], locale: string): string | null {
+  if (!value) return null;
+
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(value);
+}
+
+export function QuizList({ heading, quizzes, locale, emptyMessage, actionLabel }: QuizListProps) {
+  return (
+    <article className="card rounded-2xl border border-slate-200 bg-white p-6 shadow-sm flex flex-col gap-4">
+      <header>
+        <h2 className="text-lg font-semibold text-slate-900">{heading}</h2>
+      </header>
+
+      {quizzes.length === 0 ? (
+        <p className="text-sm text-slate-500">{emptyMessage}</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {quizzes.map((quiz) => {
+            const dueLabel = formatDate(quiz.dueAt ?? null, locale);
+
+            return (
+              <li key={quiz.id} className="flex flex-col gap-1 rounded-lg border border-slate-100 bg-slate-50/80 p-3">
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm font-semibold text-slate-800">{quiz.title ?? 'Quiz'}</span>
+                  {quiz.courseTitle ? (
+                    <span className="text-xs text-slate-500">{quiz.courseTitle}</span>
+                  ) : null}
+                  {dueLabel ? <span className="text-xs text-blue-600">{dueLabel}</span> : null}
+                </div>
+                {quiz.startUrl ? (
+                  <div>
+                    <Link
+                      href={quiz.startUrl}
+                      className="inline-flex h-9 items-center justify-center rounded-md bg-blue-600 px-3 text-xs font-semibold uppercase tracking-wide text-white transition hover:bg-blue-500"
+                      prefetch={false}
+                    >
+                      {actionLabel}
+                    </Link>
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </article>
+  );
+}
+
+export default QuizList;

--- a/web/lib/server-auth.ts
+++ b/web/lib/server-auth.ts
@@ -1,0 +1,24 @@
+import {cookies} from 'next/headers';
+import {redirect} from 'next/navigation';
+
+export type Session = {
+  accessToken: string | null;
+  refreshToken: string | null;
+  isAuthenticated: boolean;
+};
+
+export function getSession(options?: {required?: boolean}): Session {
+  const cookieStore = cookies();
+  const accessToken = cookieStore.get('accessToken')?.value ?? null;
+  const refreshToken = cookieStore.get('refreshToken')?.value ?? null;
+
+  if (!accessToken && options?.required) {
+    redirect('/auth/login');
+  }
+
+  return {
+    accessToken,
+    refreshToken,
+    isAuthenticated: Boolean(accessToken)
+  };
+}

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -79,6 +79,31 @@
     "dashboardCta": "العودة إلى لوحة التحكم",
     "error": "تعذر تحميل جلسة الدفع. حاول مرة أخرى."
   },
+  "dashboard": {
+    "title": "لوحة الطالب",
+    "description": "تابع الدروس القادمة والاختبارات وتقدمك.",
+    "nextLesson": "الدرس التالي",
+    "nextLessonEmpty": "لقد أنهيت جميع الدروس المتاحة.",
+    "openLesson": "فتح",
+    "dueQuizzes": "اختبارات مستحقة",
+    "dueQuizzesEmpty": "لا توجد اختبارات مستحقة حالياً.",
+    "startQuiz": "بدء",
+    "attendance": "الحضور",
+    "attendanceEmpty": "بيانات الحضور غير متاحة بعد.",
+    "attendanceStatus": {
+      "great": "في المسار الصحيح",
+      "warning": "واصل التقدم",
+      "danger": "يحتاج إلى متابعة"
+    },
+    "certificates": "الشهادات",
+    "certificatesEmpty": "ستظهر الشهادات هنا عند إصدارها.",
+    "viewCertificate": "عرض الشهادة",
+    "enrollments": "تسجيلاتي",
+    "enrollmentsEmpty": "لست مسجلاً في أي دورات بعد.",
+    "statusLabel": "الحالة",
+    "seatsLabel": "المقاعد المتبقية",
+    "untitledCourse": "دورة بدون عنوان"
+  },
   "weekdays": {
     "0": "الأحد",
     "1": "الاثنين",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -79,6 +79,31 @@
     "dashboardCta": "Return to dashboard",
     "error": "We couldn't load your checkout session. Please try again."
   },
+  "dashboard": {
+    "title": "Student dashboard",
+    "description": "Track upcoming lessons, quizzes, and your progress.",
+    "nextLesson": "Next Lesson",
+    "nextLessonEmpty": "You're all caught up on lessons.",
+    "openLesson": "Open",
+    "dueQuizzes": "Due Quizzes",
+    "dueQuizzesEmpty": "No quizzes are due right now.",
+    "startQuiz": "Start",
+    "attendance": "Attendance",
+    "attendanceEmpty": "Attendance data is not yet available.",
+    "attendanceStatus": {
+      "great": "On track",
+      "warning": "Keep going",
+      "danger": "Needs attention"
+    },
+    "certificates": "Certificates",
+    "certificatesEmpty": "Certificates will appear here once issued.",
+    "viewCertificate": "View certificate",
+    "enrollments": "My Enrollments",
+    "enrollmentsEmpty": "You are not enrolled in any courses yet.",
+    "statusLabel": "Status",
+    "seatsLabel": "Seats left",
+    "untitledCourse": "Untitled course"
+  },
   "weekdays": {
     "0": "Sunday",
     "1": "Monday",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -79,6 +79,31 @@
     "dashboardCta": "ダッシュボードに戻る",
     "error": "チェックアウトの読み込みに失敗しました。もう一度お試しください。"
   },
+  "dashboard": {
+    "title": "受講生ダッシュボード",
+    "description": "これからのレッスンや小テスト、進捗状況を確認しましょう。",
+    "nextLesson": "次のレッスン",
+    "nextLessonEmpty": "公開済みのレッスンはすべて確認済みです。",
+    "openLesson": "開く",
+    "dueQuizzes": "提出期限の小テスト",
+    "dueQuizzesEmpty": "現在提出期限の小テストはありません。",
+    "startQuiz": "開始",
+    "attendance": "出席状況",
+    "attendanceEmpty": "出席データはまだ利用できません。",
+    "attendanceStatus": {
+      "great": "順調です",
+      "warning": "継続しましょう",
+      "danger": "要注意"
+    },
+    "certificates": "修了証",
+    "certificatesEmpty": "修了証が発行されるとここに表示されます。",
+    "viewCertificate": "修了証を見る",
+    "enrollments": "受講中の講座",
+    "enrollmentsEmpty": "現在受講中の講座はありません。",
+    "statusLabel": "ステータス",
+    "seatsLabel": "残席",
+    "untitledCourse": "名称未設定の講座"
+  },
   "weekdays": {
     "0": "日曜",
     "1": "月曜",


### PR DESCRIPTION
## Summary
- add a cookie-based `getSession` helper for server components
- introduce authenticated API route proxies for enrollments, course content, and progress resources
- build the student dashboard with reusable cards, localized copy, and graceful fallbacks

## Testing
- CI=1 npm --prefix web run build

------
https://chatgpt.com/codex/tasks/task_e_68d4aa5fb658832f8fde6319601d2495