### PR TITLE
feat(web): add instructor portal

### DIFF
--- a/web/app/api/teach/attendance/bulk/route.ts
+++ b/web/app/api/teach/attendance/bulk/route.ts
@@ -1,0 +1,25 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+import {forwardProxyResponse} from '../../utils';
+
+export async function POST(request: NextRequest) {
+  const payload = await request.json().catch(() => null);
+
+  if (!payload) {
+    return NextResponse.json({ message: 'Request body is required' }, { status: 400 });
+  }
+
+  try {
+    const response = await authorizedFetch('/attendance/checkin', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+
+    return forwardProxyResponse(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to submit attendance';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/web/app/api/teach/lessons/[id]/route.ts
+++ b/web/app/api/teach/lessons/[id]/route.ts
@@ -1,0 +1,31 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+import {forwardProxyResponse} from '../../utils';
+
+export async function PATCH(request: NextRequest, {params}: { params: { id: string } }) {
+  const {id} = params;
+
+  if (!id) {
+    return NextResponse.json({ message: 'Lesson id is required' }, { status: 400 });
+  }
+
+  const payload = await request.json().catch(() => null);
+
+  if (!payload || typeof payload !== 'object') {
+    return NextResponse.json({ message: 'Request body is required' }, { status: 400 });
+  }
+
+  try {
+    const response = await authorizedFetch(`/lessons/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload)
+    });
+
+    return forwardProxyResponse(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to update lesson';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/web/app/api/teach/lessons/route.ts
+++ b/web/app/api/teach/lessons/route.ts
@@ -1,0 +1,25 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+import {forwardProxyResponse} from '../utils';
+
+export async function POST(request: NextRequest) {
+  const payload = await request.json().catch(() => null);
+
+  if (!payload || typeof payload !== 'object') {
+    return NextResponse.json({ message: 'Request body is required' }, { status: 400 });
+  }
+
+  try {
+    const response = await authorizedFetch('/lessons', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+
+    return forwardProxyResponse(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to create lesson';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/web/app/api/teach/quizzes/[id]/route.ts
+++ b/web/app/api/teach/quizzes/[id]/route.ts
@@ -1,0 +1,31 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+import {forwardProxyResponse} from '../../utils';
+
+export async function PATCH(request: NextRequest, {params}: { params: { id: string } }) {
+  const {id} = params;
+
+  if (!id) {
+    return NextResponse.json({ message: 'Quiz id is required' }, { status: 400 });
+  }
+
+  const payload = await request.json().catch(() => null);
+
+  if (!payload || typeof payload !== 'object') {
+    return NextResponse.json({ message: 'Request body is required' }, { status: 400 });
+  }
+
+  try {
+    const response = await authorizedFetch(`/quizzes/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload)
+    });
+
+    return forwardProxyResponse(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to update quiz';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/web/app/api/teach/quizzes/route.ts
+++ b/web/app/api/teach/quizzes/route.ts
@@ -1,0 +1,25 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+import {forwardProxyResponse} from '../utils';
+
+export async function POST(request: NextRequest) {
+  const payload = await request.json().catch(() => null);
+
+  if (!payload || typeof payload !== 'object') {
+    return NextResponse.json({ message: 'Request body is required' }, { status: 400 });
+  }
+
+  try {
+    const response = await authorizedFetch('/quizzes', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+
+    return forwardProxyResponse(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to create quiz';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/web/app/api/teach/roster/[sectionId]/route.ts
+++ b/web/app/api/teach/roster/[sectionId]/route.ts
@@ -1,0 +1,22 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+import {forwardProxyResponse} from '../../utils';
+
+export async function GET(_: NextRequest, {params}: { params: { sectionId: string } }) {
+  const {sectionId} = params;
+
+  if (!sectionId) {
+    return NextResponse.json({ message: 'sectionId is required' }, { status: 400 });
+  }
+
+  try {
+    const search = new URLSearchParams({ sectionId: String(sectionId) });
+    const response = await authorizedFetch(`/enrollments?${search.toString()}`, { method: 'GET' });
+    return forwardProxyResponse(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to load roster';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/web/app/api/teach/sections/route.ts
+++ b/web/app/api/teach/sections/route.ts
@@ -1,0 +1,35 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch, fetchCurrentUser} from '@/lib/server/api';
+
+import {forwardProxyResponse} from '../utils';
+
+function shouldFallback(status: number): boolean {
+  if (status === 400 || status === 404 || status === 422 || status === 405) {
+    return true;
+  }
+
+  return false;
+}
+
+export async function GET(_: NextRequest) {
+  try {
+    let response = await authorizedFetch('/sections?mine=true', { method: 'GET' });
+
+    if (!response.ok && shouldFallback(response.status)) {
+      const currentUser = await fetchCurrentUser<{ id?: string }>();
+
+      if (!currentUser?.id) {
+        return NextResponse.json({ message: 'Unable to identify instructor account' }, { status: 403 });
+      }
+
+      const search = new URLSearchParams({ instructorId: String(currentUser.id) });
+      response = await authorizedFetch(`/sections?${search.toString()}`, { method: 'GET' });
+    }
+
+    return forwardProxyResponse(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to load sections';
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/web/app/api/teach/utils.ts
+++ b/web/app/api/teach/utils.ts
@@ -1,0 +1,34 @@
+import {NextResponse} from 'next/server';
+
+export async function forwardProxyResponse(response: Response): Promise<NextResponse> {
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const body = await response.json().catch(() => ({}));
+      return NextResponse.json(body, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: {
+        'content-type': contentType ?? 'text/plain'
+      }
+    });
+  }
+
+  if (!isJson) {
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: {
+        'content-type': contentType ?? 'text/plain'
+      }
+    });
+  }
+
+  const data = await response.json().catch(() => ({}));
+  return NextResponse.json(data, { status: response.status });
+}

--- a/web/app/teach/page.tsx
+++ b/web/app/teach/page.tsx
@@ -1,0 +1,56 @@
+import {redirect} from 'next/navigation';
+
+import {SectionList} from '@/components/teach/section-list';
+import {fetchCurrentInstructor, hasInstructorAccess} from '@/lib/teach/auth';
+import {fetchInstructorSections} from '@/lib/teach/sections';
+
+export const dynamic = 'force-dynamic';
+
+export default async function TeachLandingPage() {
+  const { user, status: userStatus } = await fetchCurrentInstructor();
+
+  if (userStatus === 401 || (!user && userStatus == null)) {
+    redirect('/auth/login');
+  }
+
+  if (!user) {
+    return (
+      <section className="card">
+        <h1 style={{ margin: 0 }}>Instructor portal</h1>
+        <p style={{ margin: 0, color: '#4b5563' }}>We could not verify your account. Please try again later.</p>
+      </section>
+    );
+  }
+
+  if (!hasInstructorAccess(user)) {
+    return (
+        <section className="card" style={{ gap: '0.75rem' }}>
+          <h1 style={{ margin: 0 }}>Instructor portal</h1>
+          <div className="error-state" style={{ textAlign: 'left' }}>
+            You don't have permission to access the instructor portal.
+          </div>
+        </section>
+    );
+  }
+
+  const { sections, error: sectionsError } = await fetchInstructorSections();
+
+  return (
+    <section className="card" style={{ gap: '1rem' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+        <h1 style={{ margin: 0 }}>Instructor portal</h1>
+        <p style={{ margin: 0, color: '#4b5563' }}>
+          Review your assigned sections and manage roster, lessons, and quizzes.
+        </p>
+      </div>
+
+      {sectionsError ? (
+        <div className="error-state" style={{ textAlign: 'left' }}>
+          {sectionsError}
+        </div>
+      ) : (
+        <SectionList sections={sections} emptyMessage="No sections assigned to you yet." />
+      )}
+    </section>
+  );
+}

--- a/web/app/teach/sections/[id]/page.tsx
+++ b/web/app/teach/sections/[id]/page.tsx
@@ -1,0 +1,212 @@
+import Link from 'next/link';
+import {redirect} from 'next/navigation';
+
+import {SectionTabs} from '@/components/teach/section-tabs';
+import {fetchCurrentInstructor, hasInstructorAccess} from '@/lib/teach/auth';
+import {normaliseRoster} from '@/lib/teach/normalise';
+import {fetchInstructorSections} from '@/lib/teach/sections';
+import type {InstructorSection, RosterEntry} from '@/types/teach';
+import {internalFetch} from '@/lib/server/internal-api';
+
+export const dynamic = 'force-dynamic';
+
+interface SectionDetailPageProps {
+  params: { id: string };
+}
+
+function formatWeekday(weekday?: number | null): string | null {
+  if (weekday == null) {
+    return null;
+  }
+
+  const parsed = Number(weekday);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  const labels = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+  if (parsed >= 0 && parsed <= 6) {
+    return labels[parsed];
+  }
+
+  if (parsed >= 1 && parsed <= 7) {
+    return labels[(parsed - 1) % 7];
+  }
+
+  const normalised = ((parsed % 7) + 7) % 7;
+  return labels[normalised];
+}
+
+function formatTime(value?: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const dateValue = value.includes('T') ? value : `1970-01-01T${value}`;
+
+  try {
+    const date = new Date(dateValue);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+
+    return new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit' }).format(date);
+  } catch {
+    return value;
+  }
+}
+
+function describeSection(section: InstructorSection | null | undefined): string | null {
+  if (!section) {
+    return null;
+  }
+
+  const weekday = formatWeekday(section.weekday);
+  const start = formatTime(section.startTime);
+  const end = formatTime(section.endTime);
+
+  if (weekday && start && end) {
+    return `${weekday} · ${start} – ${end}`;
+  }
+
+  if (weekday && start) {
+    return `${weekday} · ${start}`;
+  }
+
+  if (weekday) {
+    return weekday;
+  }
+
+  if (start && end) {
+    return `${start} – ${end}`;
+  }
+
+  return null;
+}
+
+async function fetchRoster(sectionId: string): Promise<{
+  roster: RosterEntry[];
+  status?: number;
+  error?: string;
+}> {
+  try {
+    const response = await internalFetch(`/api/teach/roster/${encodeURIComponent(sectionId)}`, { method: 'GET' });
+    const contentType = response.headers.get('content-type');
+    const isJson = contentType?.includes('application/json');
+
+    if (!response.ok) {
+      if (isJson) {
+        const body = await response.json().catch(() => ({}));
+        const message = typeof body?.message === 'string' ? body.message : 'Unable to load roster';
+        return { roster: [], status: response.status, error: message };
+      }
+
+      return { roster: [], status: response.status, error: 'Unable to load roster' };
+    }
+
+    if (!isJson) {
+      return { roster: [], status: response.status, error: 'Roster response was not JSON' };
+    }
+
+    const data = await response.json();
+    const roster = normaliseRoster(data);
+    return { roster, status: response.status };
+  } catch (error) {
+    return { roster: [], error: error instanceof Error ? error.message : 'Unable to load roster' };
+  }
+}
+
+export default async function SectionDetailPage({ params }: SectionDetailPageProps) {
+  const sectionId = params.id;
+  const { user, status: userStatus } = await fetchCurrentInstructor();
+
+  if (userStatus === 401 || (!user && userStatus == null)) {
+    redirect('/auth/login');
+  }
+
+  if (!user) {
+    return (
+      <section className="card" style={{ gap: '0.75rem' }}>
+        <h1 style={{ margin: 0 }}>Section management</h1>
+        <div className="error-state" style={{ textAlign: 'left' }}>
+          We could not verify your account. Please try again later.
+        </div>
+      </section>
+    );
+  }
+
+  if (!hasInstructorAccess(user)) {
+    return (
+      <section className="card" style={{ gap: '0.75rem' }}>
+        <h1 style={{ margin: 0 }}>Section management</h1>
+        <div className="error-state" style={{ textAlign: 'left' }}>
+          You don't have access to this section.
+        </div>
+      </section>
+    );
+  }
+
+  const [sectionsResult, rosterResult] = await Promise.all([fetchInstructorSections(), fetchRoster(sectionId)]);
+  const section = sectionsResult.sections.find((item) => item.id === sectionId) ?? null;
+  const heading = section?.title ?? section?.courseTitle ?? section?.courseCode ?? `Section ${sectionId}`;
+  const scheduleDescription = describeSection(section);
+
+  const rosterErrorMessage =
+    rosterResult.status === 403 ? "You don't have access to this section." : rosterResult.error ?? null;
+
+  const backendAvailable = Boolean(process.env.NEXT_PUBLIC_API_BASE_URL);
+  const attendanceDisabled = !backendAvailable || rosterResult.status === 403;
+  const lessonDisabled = !backendAvailable;
+  const quizDisabled = !backendAvailable;
+
+  const defaultDate = new Date().toISOString().slice(0, 10);
+
+  return (
+    <section className="card" style={{ gap: '1.5rem' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <Link href="/teach" className="nav-link" style={{ fontSize: '0.95rem' }}>
+          ← Back to sections
+        </Link>
+        <h1 style={{ margin: 0 }}>{heading}</h1>
+        {section?.courseTitle && section.courseTitle !== heading ? (
+          <p style={{ margin: 0, color: '#6b7280' }}>{section.courseTitle}</p>
+        ) : null}
+        {scheduleDescription ? (
+          <p style={{ margin: 0, color: '#4b5563' }}>{scheduleDescription}</p>
+        ) : null}
+        {sectionsResult.error ? (
+          <p style={{ margin: 0, color: '#b91c1c' }}>{sectionsResult.error}</p>
+        ) : null}
+        {!backendAvailable ? (
+          <p style={{ margin: 0, color: '#b45309' }}>
+            API connectivity is not configured yet. Actions are temporarily read-only.
+          </p>
+        ) : null}
+      </div>
+
+      <SectionTabs
+        sectionId={sectionId}
+        roster={{
+          students: rosterResult.roster,
+          defaultDate,
+          disabled: attendanceDisabled,
+          disabledReason: !backendAvailable
+            ? 'Attendance service is not available yet.'
+            : rosterResult.status === 403
+              ? "You don't have access to this section."
+              : undefined,
+          errorMessage: rosterErrorMessage
+        }}
+        lessonForm={{
+          disabled: lessonDisabled,
+          disabledReason: !backendAvailable ? 'Lesson endpoints are not available yet.' : undefined
+        }}
+        quizForm={{
+          disabled: quizDisabled,
+          disabledReason: !backendAvailable ? 'Quiz endpoints are not available yet.' : undefined
+        }}
+      />
+    </section>
+  );
+}

--- a/web/components/teach/lesson-form.tsx
+++ b/web/components/teach/lesson-form.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import {FormEvent, useEffect, useMemo, useState} from 'react';
+
+interface LessonFormProps {
+  sectionId: string;
+  disabled?: boolean;
+  disabledReason?: string;
+  initialLesson?: {
+    id?: string;
+    title?: string | null;
+    videoUrl?: string | null;
+    releaseAt?: string | null;
+  } | null;
+}
+
+type LessonMode = 'create' | 'update';
+
+type ToastState = {
+  variant: 'success' | 'error';
+  message: string;
+};
+
+function toInputDate(value?: string | null): string {
+  if (!value) {
+    return '';
+  }
+
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+
+    const iso = date.toISOString();
+    return iso.slice(0, 16);
+  } catch {
+    return '';
+  }
+}
+
+function toIsoString(value: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return undefined;
+    }
+
+    return date.toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
+export function LessonForm({ sectionId, disabled = false, disabledReason, initialLesson = null }: LessonFormProps) {
+  const [mode, setMode] = useState<LessonMode>(initialLesson?.id ? 'update' : 'create');
+  const [lessonId, setLessonId] = useState(initialLesson?.id ?? '');
+  const [title, setTitle] = useState(initialLesson?.title ?? '');
+  const [videoUrl, setVideoUrl] = useState(initialLesson?.videoUrl ?? '');
+  const [releaseAt, setReleaseAt] = useState(toInputDate(initialLesson?.releaseAt ?? null));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+
+    const timeout = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(timeout);
+  }, [toast]);
+
+  useEffect(() => {
+    if (!initialLesson) {
+      return;
+    }
+
+    setLessonId(initialLesson.id ?? '');
+    setTitle(initialLesson.title ?? '');
+    setVideoUrl(initialLesson.videoUrl ?? '');
+    setReleaseAt(toInputDate(initialLesson.releaseAt ?? null));
+    setMode(initialLesson.id ? 'update' : 'create');
+  }, [initialLesson]);
+
+  const actionLabel = useMemo(() => (mode === 'create' ? 'Create lesson' : 'Update lesson'), [mode]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (disabled || isSubmitting) {
+      return;
+    }
+
+    if (!title.trim()) {
+      setToast({ variant: 'error', message: 'Title is required.' });
+      return;
+    }
+
+    if (mode === 'update' && !lessonId.trim()) {
+      setToast({ variant: 'error', message: 'Lesson ID is required to update.' });
+      return;
+    }
+
+    setIsSubmitting(true);
+    setToast(null);
+
+    const body: Record<string, unknown> = {
+      sectionId,
+      title: title.trim()
+    };
+
+    if (videoUrl.trim()) {
+      body.videoUrl = videoUrl.trim();
+    }
+
+    const releaseIso = toIsoString(releaseAt);
+    if (releaseIso) {
+      body.releaseAt = releaseIso;
+    }
+
+    const url = mode === 'create' ? '/api/teach/lessons' : `/api/teach/lessons/${encodeURIComponent(lessonId.trim())}`;
+    const method = mode === 'create' ? 'POST' : 'PATCH';
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(body),
+        cache: 'no-store'
+      });
+
+      if (!response.ok) {
+        const contentType = response.headers.get('content-type');
+        if (contentType?.includes('application/json')) {
+          const errorBody = await response.json().catch(() => ({}));
+          const message = typeof errorBody?.message === 'string' ? errorBody.message : 'Unable to save lesson.';
+          throw new Error(message);
+        }
+
+        throw new Error('Unable to save lesson.');
+      }
+
+      setToast({ variant: 'success', message: mode === 'create' ? 'Lesson created.' : 'Lesson updated.' });
+
+      if (mode === 'create') {
+        setTitle('');
+        setVideoUrl('');
+        setReleaseAt('');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to save lesson.';
+      setToast({ variant: 'error', message });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      {toast ? <div className={`toast toast--${toast.variant}`}>{toast.message}</div> : null}
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+        <label htmlFor="lesson-mode" style={{ fontWeight: 600 }}>
+          Action
+        </label>
+        <select
+          id="lesson-mode"
+          value={mode}
+          onChange={(event) => setMode(event.target.value as LessonMode)}
+          disabled={disabled || isSubmitting}
+          style={{
+            borderRadius: '0.5rem',
+            border: '1px solid #d1d5db',
+            padding: '0.5rem 0.75rem'
+          }}
+        >
+          <option value="create">Create new lesson</option>
+          <option value="update">Update existing lesson</option>
+        </select>
+      </div>
+
+      {mode === 'update' ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <label htmlFor="lesson-id" style={{ fontWeight: 600 }}>
+            Lesson ID
+          </label>
+          <input
+            id="lesson-id"
+            type="text"
+            value={lessonId}
+            onChange={(event) => setLessonId(event.target.value)}
+            disabled={disabled || isSubmitting}
+            required={mode === 'update'}
+            placeholder="Enter existing lesson id"
+            style={{
+              borderRadius: '0.5rem',
+              border: '1px solid #d1d5db',
+              padding: '0.5rem 0.75rem'
+            }}
+          />
+        </div>
+      ) : null}
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="lesson-title" style={{ fontWeight: 600 }}>
+          Title
+        </label>
+        <input
+          id="lesson-title"
+          type="text"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          disabled={disabled || isSubmitting}
+          placeholder="Lesson title"
+          style={{
+            borderRadius: '0.5rem',
+            border: '1px solid #d1d5db',
+            padding: '0.5rem 0.75rem'
+          }}
+        />
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="lesson-video" style={{ fontWeight: 600 }}>
+          Video URL
+        </label>
+        <input
+          id="lesson-video"
+          type="url"
+          value={videoUrl}
+          onChange={(event) => setVideoUrl(event.target.value)}
+          disabled={disabled || isSubmitting}
+          placeholder="https://example.com/lesson"
+          style={{
+            borderRadius: '0.5rem',
+            border: '1px solid #d1d5db',
+            padding: '0.5rem 0.75rem'
+          }}
+        />
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="lesson-release" style={{ fontWeight: 600 }}>
+          Release at
+        </label>
+        <input
+          id="lesson-release"
+          type="datetime-local"
+          value={releaseAt}
+          onChange={(event) => setReleaseAt(event.target.value)}
+          disabled={disabled || isSubmitting}
+          style={{
+            borderRadius: '0.5rem',
+            border: '1px solid #d1d5db',
+            padding: '0.5rem 0.75rem'
+          }}
+        />
+      </div>
+
+      {disabledReason ? (
+        <div className="error-state" style={{ textAlign: 'left' }}>
+          {disabledReason}
+        </div>
+      ) : null}
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <button
+          type="submit"
+          className="button"
+          disabled={disabled || isSubmitting}
+          style={{ opacity: disabled || isSubmitting ? 0.7 : 1 }}
+        >
+          {isSubmitting ? 'Saving…' : actionLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/components/teach/quiz-form.tsx
+++ b/web/components/teach/quiz-form.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import {FormEvent, useEffect, useMemo, useState} from 'react';
+
+interface QuizFormProps {
+  sectionId: string;
+  disabled?: boolean;
+  disabledReason?: string;
+  initialQuiz?: {
+    id?: string;
+    title?: string | null;
+    totalPoints?: number | null;
+    availableFrom?: string | null;
+    dueAt?: string | null;
+  } | null;
+}
+
+type QuizMode = 'create' | 'update';
+
+type ToastState = {
+  variant: 'success' | 'error';
+  message: string;
+};
+
+function toInputDateTime(value?: string | null): string {
+  if (!value) {
+    return '';
+  }
+
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+
+    return date.toISOString().slice(0, 16);
+  } catch {
+    return '';
+  }
+}
+
+function toIso(value: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return undefined;
+    }
+
+    return date.toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
+export function QuizForm({ sectionId, disabled = false, disabledReason, initialQuiz = null }: QuizFormProps) {
+  const [mode, setMode] = useState<QuizMode>(initialQuiz?.id ? 'update' : 'create');
+  const [quizId, setQuizId] = useState(initialQuiz?.id ?? '');
+  const [title, setTitle] = useState(initialQuiz?.title ?? '');
+  const [totalPoints, setTotalPoints] = useState(
+    initialQuiz?.totalPoints != null ? String(initialQuiz.totalPoints) : ''
+  );
+  const [availableFrom, setAvailableFrom] = useState(toInputDateTime(initialQuiz?.availableFrom ?? null));
+  const [dueAt, setDueAt] = useState(toInputDateTime(initialQuiz?.dueAt ?? null));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+
+    const timeout = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(timeout);
+  }, [toast]);
+
+  useEffect(() => {
+    if (!initialQuiz) {
+      return;
+    }
+
+    setQuizId(initialQuiz.id ?? '');
+    setTitle(initialQuiz.title ?? '');
+    setTotalPoints(initialQuiz.totalPoints != null ? String(initialQuiz.totalPoints) : '');
+    setAvailableFrom(toInputDateTime(initialQuiz.availableFrom ?? null));
+    setDueAt(toInputDateTime(initialQuiz.dueAt ?? null));
+    setMode(initialQuiz.id ? 'update' : 'create');
+  }, [initialQuiz]);
+
+  const actionLabel = useMemo(() => (mode === 'create' ? 'Create quiz' : 'Update quiz'), [mode]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (disabled || isSubmitting) {
+      return;
+    }
+
+    if (!title.trim()) {
+      setToast({ variant: 'error', message: 'Title is required.' });
+      return;
+    }
+
+    if (mode === 'update' && !quizId.trim()) {
+      setToast({ variant: 'error', message: 'Quiz ID is required to update.' });
+      return;
+    }
+
+    const points = totalPoints.trim() ? Number(totalPoints) : null;
+
+    if (points != null && (!Number.isFinite(points) || points < 0)) {
+      setToast({ variant: 'error', message: 'Total points must be a positive number.' });
+      return;
+    }
+
+    setIsSubmitting(true);
+    setToast(null);
+
+    const body: Record<string, unknown> = {
+      sectionId,
+      title: title.trim()
+    };
+
+    if (points != null) {
+      body.totalPoints = points;
+    }
+
+    const availableIso = toIso(availableFrom);
+    if (availableIso) {
+      body.availableFrom = availableIso;
+    }
+
+    const dueIso = toIso(dueAt);
+    if (dueIso) {
+      body.dueAt = dueIso;
+    }
+
+    const url = mode === 'create' ? '/api/teach/quizzes' : `/api/teach/quizzes/${encodeURIComponent(quizId.trim())}`;
+    const method = mode === 'create' ? 'POST' : 'PATCH';
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(body),
+        cache: 'no-store'
+      });
+
+      if (!response.ok) {
+        const contentType = response.headers.get('content-type');
+        if (contentType?.includes('application/json')) {
+          const errorBody = await response.json().catch(() => ({}));
+          const message = typeof errorBody?.message === 'string' ? errorBody.message : 'Unable to save quiz.';
+          throw new Error(message);
+        }
+
+        throw new Error('Unable to save quiz.');
+      }
+
+      setToast({ variant: 'success', message: mode === 'create' ? 'Quiz created.' : 'Quiz updated.' });
+
+      if (mode === 'create') {
+        setTitle('');
+        setTotalPoints('');
+        setAvailableFrom('');
+        setDueAt('');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to save quiz.';
+      setToast({ variant: 'error', message });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      {toast ? <div className={`toast toast--${toast.variant}`}>{toast.message}</div> : null}
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+        <label htmlFor="quiz-mode" style={{ fontWeight: 600 }}>
+          Action
+        </label>
+        <select
+          id="quiz-mode"
+          value={mode}
+          onChange={(event) => setMode(event.target.value as QuizMode)}
+          disabled={disabled || isSubmitting}
+          style={{
+            borderRadius: '0.5rem',
+            border: '1px solid #d1d5db',
+            padding: '0.5rem 0.75rem'
+          }}
+        >
+          <option value="create">Create new quiz</option>
+          <option value="update">Update existing quiz</option>
+        </select>
+      </div>
+
+      {mode === 'update' ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <label htmlFor="quiz-id" style={{ fontWeight: 600 }}>
+            Quiz ID
+          </label>
+          <input
+            id="quiz-id"
+            type="text"
+            value={quizId}
+            onChange={(event) => setQuizId(event.target.value)}
+            disabled={disabled || isSubmitting}
+            required={mode === 'update'}
+            placeholder="Enter existing quiz id"
+            style={{
+              borderRadius: '0.5rem',
+              border: '1px solid #d1d5db',
+              padding: '0.5rem 0.75rem'
+            }}
+          />
+        </div>
+      ) : null}
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="quiz-title" style={{ fontWeight: 600 }}>
+          Title
+        </label>
+        <input
+          id="quiz-title"
+          type="text"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          disabled={disabled || isSubmitting}
+          placeholder="Quiz title"
+          style={{
+            borderRadius: '0.5rem',
+            border: '1px solid #d1d5db',
+            padding: '0.5rem 0.75rem'
+          }}
+        />
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="quiz-points" style={{ fontWeight: 600 }}>
+          Total points
+        </label>
+        <input
+          id="quiz-points"
+          type="number"
+          min={0}
+          value={totalPoints}
+          onChange={(event) => setTotalPoints(event.target.value)}
+          disabled={disabled || isSubmitting}
+          placeholder="e.g. 100"
+          style={{
+            borderRadius: '0.5rem',
+            border: '1px solid #d1d5db',
+            padding: '0.5rem 0.75rem'
+          }}
+        />
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="quiz-available" style={{ fontWeight: 600 }}>
+          Available from
+        </label>
+        <input
+          id="quiz-available"
+          type="datetime-local"
+          value={availableFrom}
+          onChange={(event) => setAvailableFrom(event.target.value)}
+          disabled={disabled || isSubmitting}
+          style={{
+            borderRadius: '0.5rem',
+            border: '1px solid #d1d5db',
+            padding: '0.5rem 0.75rem'
+          }}
+        />
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <label htmlFor="quiz-due" style={{ fontWeight: 600 }}>
+          Due at
+        </label>
+        <input
+          id="quiz-due"
+          type="datetime-local"
+          value={dueAt}
+          onChange={(event) => setDueAt(event.target.value)}
+          disabled={disabled || isSubmitting}
+          style={{
+            borderRadius: '0.5rem',
+            border: '1px solid #d1d5db',
+            padding: '0.5rem 0.75rem'
+          }}
+        />
+      </div>
+
+      {disabledReason ? (
+        <div className="error-state" style={{ textAlign: 'left' }}>
+          {disabledReason}
+        </div>
+      ) : null}
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <button
+          type="submit"
+          className="button"
+          disabled={disabled || isSubmitting}
+          style={{ opacity: disabled || isSubmitting ? 0.7 : 1 }}
+        >
+          {isSubmitting ? 'Saving…' : actionLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/components/teach/roster-table.tsx
+++ b/web/components/teach/roster-table.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import {FormEvent, useEffect, useMemo, useState} from 'react';
+
+import type {RosterEntry} from '@/types/teach';
+import {combineName} from '@/lib/format';
+
+type ToastState = {
+  variant: 'success' | 'error';
+  message: string;
+};
+
+export interface RosterStudent extends RosterEntry {
+  name: string;
+}
+
+interface RosterTableProps {
+  sectionId: string;
+  students: RosterEntry[];
+  defaultDate: string;
+  disabled?: boolean;
+  disabledReason?: string;
+  successMessage?: string;
+  errorMessage?: string;
+}
+
+interface AttendanceRecord {
+  userId: string;
+  present: boolean;
+  note: string;
+}
+
+function buildStudentName(entry: RosterEntry): string {
+  const combined = combineName({
+    firstName: entry.firstName,
+    lastName: entry.lastName,
+    displayName: entry.displayName
+  });
+
+  if (combined) {
+    return combined;
+  }
+
+  if (entry.email) {
+    return entry.email;
+  }
+
+  return `Student ${entry.userId}`;
+}
+
+function normaliseStudents(entries: RosterEntry[]): RosterStudent[] {
+  return entries.map((entry) => ({
+    ...entry,
+    name: buildStudentName(entry)
+  }));
+}
+
+export function RosterTable({
+  sectionId,
+  students,
+  defaultDate,
+  disabled = false,
+  disabledReason,
+  successMessage = 'Attendance saved successfully.',
+  errorMessage = 'Unable to submit attendance.'
+}: RosterTableProps) {
+  const [meetingDate, setMeetingDate] = useState(defaultDate);
+  const [records, setRecords] = useState<AttendanceRecord[]>(() =>
+    students.map((student) => ({ userId: student.userId, present: true, note: '' }))
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const roster = useMemo(() => normaliseStudents(students), [students]);
+
+  useEffect(() => {
+    setRecords(students.map((student) => ({ userId: student.userId, present: true, note: '' })));
+  }, [students]);
+
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+
+    const timeout = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(timeout);
+  }, [toast]);
+
+  const handleToggle = (userId: string) => {
+    setRecords((prev) =>
+      prev.map((record) => (record.userId === userId ? { ...record, present: !record.present } : record))
+    );
+  };
+
+  const handleNoteChange = (userId: string, note: string) => {
+    setRecords((prev) => prev.map((record) => (record.userId === userId ? { ...record, note } : record)));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (disabled || isSubmitting || !roster.length) {
+      return;
+    }
+
+    if (!meetingDate) {
+      setToast({ variant: 'error', message: 'Please choose a meeting date.' });
+      return;
+    }
+
+    setIsSubmitting(true);
+    setToast(null);
+
+    try {
+      const payload = records.map((record) => ({
+        sectionId,
+        userId: record.userId,
+        meetingDate,
+        present: record.present,
+        ...(record.note ? { note: record.note } : {})
+      }));
+
+      const response = await fetch('/api/teach/attendance/bulk', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload),
+        cache: 'no-store'
+      });
+
+      if (!response.ok) {
+        const contentType = response.headers.get('content-type');
+        if (contentType?.includes('application/json')) {
+          const body = await response.json().catch(() => ({}));
+          const message = typeof body?.message === 'string' ? body.message : errorMessage;
+          throw new Error(message);
+        }
+
+        throw new Error(errorMessage);
+      }
+
+      setToast({ variant: 'success', message: successMessage });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : errorMessage;
+      setToast({ variant: 'error', message });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      {toast ? <div className={`toast toast--${toast.variant}`}>{toast.message}</div> : null}
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', alignItems: 'center' }}>
+        <label htmlFor="attendance-date" style={{ fontWeight: 600 }}>
+          Meeting date
+        </label>
+        <input
+          id="attendance-date"
+          type="date"
+          value={meetingDate}
+          onChange={(event) => setMeetingDate(event.target.value)}
+          disabled={disabled || isSubmitting}
+          style={{
+            borderRadius: '0.5rem',
+            border: '1px solid #d1d5db',
+            padding: '0.5rem 0.75rem',
+            backgroundColor: disabled ? '#f3f4f6' : '#fff'
+          }}
+        />
+      </div>
+
+      {disabledReason ? (
+        <div className="error-state" style={{ textAlign: 'left' }}>
+          {disabledReason}
+        </div>
+      ) : null}
+
+      {roster.length ? (
+        <div style={{ overflowX: 'auto' }}>
+          <table className="list-table">
+            <thead>
+              <tr>
+                <th>Student</th>
+                <th>Email</th>
+                <th>Present</th>
+                <th>Note</th>
+              </tr>
+            </thead>
+            <tbody>
+              {roster.map((student) => {
+                const record = records.find((item) => item.userId === student.userId);
+
+                return (
+                  <tr key={student.userId}>
+                    <td>{student.name}</td>
+                    <td style={{ color: '#6b7280' }}>{student.email ?? '—'}</td>
+                    <td>
+                      <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                        <input
+                          type="checkbox"
+                          checked={record?.present ?? false}
+                          onChange={() => handleToggle(student.userId)}
+                          disabled={disabled || isSubmitting}
+                        />
+                        <span>{record?.present ? 'Present' : 'Absent'}</span>
+                      </label>
+                    </td>
+                    <td>
+                      <input
+                        type="text"
+                        value={record?.note ?? ''}
+                        onChange={(event) => handleNoteChange(student.userId, event.target.value)}
+                        disabled={disabled || isSubmitting}
+                        placeholder="Optional note"
+                        style={{
+                          width: '100%',
+                          borderRadius: '0.5rem',
+                          border: '1px solid #d1d5db',
+                          padding: '0.4rem 0.6rem'
+                        }}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="empty-state" style={{ textAlign: 'left' }}>
+          No students enrolled in this section yet.
+        </div>
+      )}
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <button
+          type="submit"
+          className="button"
+          disabled={disabled || isSubmitting || !roster.length}
+          style={{ opacity: disabled || isSubmitting || !roster.length ? 0.7 : 1 }}
+        >
+          {isSubmitting ? 'Submitting...' : 'Save attendance'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/components/teach/section-list.tsx
+++ b/web/components/teach/section-list.tsx
@@ -1,0 +1,113 @@
+import Link from 'next/link';
+
+import type {InstructorSection} from '@/types/teach';
+
+const WEEKDAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+function formatWeekday(weekday?: number | null): string | null {
+  if (weekday == null) {
+    return null;
+  }
+
+  const parsed = Number(weekday);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  if (parsed >= 0 && parsed <= 6) {
+    return WEEKDAY_LABELS[parsed];
+  }
+
+  if (parsed >= 1 && parsed <= 7) {
+    return WEEKDAY_LABELS[(parsed - 1) % 7];
+  }
+
+  const normalised = ((parsed % 7) + 7) % 7;
+  return WEEKDAY_LABELS[normalised];
+}
+
+function formatTime(value?: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const dateValue = value.includes('T') ? value : `1970-01-01T${value}`;
+
+  try {
+    const date = new Date(dateValue);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+
+    return new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit' }).format(date);
+  } catch {
+    return value;
+  }
+}
+
+function formatSchedule(section: InstructorSection): string {
+  const weekday = formatWeekday(section.weekday);
+  const start = formatTime(section.startTime);
+  const end = formatTime(section.endTime);
+
+  if (weekday && start && end) {
+    return `${weekday} · ${start} – ${end}`;
+  }
+
+  if (weekday && start) {
+    return `${weekday} · ${start}`;
+  }
+
+  if (weekday) {
+    return weekday;
+  }
+
+  if (start && end) {
+    return `${start} – ${end}`;
+  }
+
+  return 'Schedule to be announced';
+}
+
+interface SectionListProps {
+  sections: InstructorSection[];
+  emptyMessage?: string;
+}
+
+export function SectionList({sections, emptyMessage = 'No sections assigned yet.'}: SectionListProps) {
+  if (!sections.length) {
+    return <div className="empty-state">{emptyMessage}</div>;
+  }
+
+  return (
+    <div className="card-grid">
+      {sections.map((section) => {
+        const schedule = formatSchedule(section);
+        const heading = section.title ?? section.courseTitle ?? section.courseCode ?? `Section ${section.id}`;
+
+        return (
+          <Link
+            key={section.id}
+            href={`/teach/sections/${encodeURIComponent(section.id)}`}
+            className="card"
+            style={{ gap: '0.5rem' }}
+          >
+            <h2 style={{ margin: 0 }}>{heading}</h2>
+            {section.courseTitle && section.courseTitle !== heading ? (
+              <p style={{ margin: 0, color: '#6b7280' }}>{section.courseTitle}</p>
+            ) : null}
+            {section.courseCode ? (
+              <span className="badge">{section.courseCode}</span>
+            ) : null}
+            <p style={{ margin: 0, color: '#4b5563' }}>{schedule}</p>
+            <footer>
+              <span className="nav-link" style={{ fontWeight: 600, color: '#2563eb' }}>
+                Manage section →
+              </span>
+            </footer>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/components/teach/section-tabs.tsx
+++ b/web/components/teach/section-tabs.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import {useState} from 'react';
+
+import type {RosterEntry} from '@/types/teach';
+
+import {LessonForm} from './lesson-form';
+import {QuizForm} from './quiz-form';
+import {RosterTable} from './roster-table';
+
+type TabKey = 'roster' | 'lessons' | 'quizzes';
+
+interface SectionTabsProps {
+  sectionId: string;
+  roster: {
+    students: RosterEntry[];
+    defaultDate: string;
+    disabled?: boolean;
+    disabledReason?: string;
+    errorMessage?: string | null;
+  };
+  lessonForm: {
+    disabled?: boolean;
+    disabledReason?: string;
+  };
+  quizForm: {
+    disabled?: boolean;
+    disabledReason?: string;
+  };
+}
+
+const TAB_LABELS: Record<TabKey, string> = {
+  roster: 'Roster & Attendance',
+  lessons: 'Lessons',
+  quizzes: 'Quizzes'
+};
+
+export function SectionTabs({ sectionId, roster, lessonForm, quizForm }: SectionTabsProps) {
+  const [activeTab, setActiveTab] = useState<TabKey>('roster');
+
+  const renderTabs = () => (
+    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+      {(Object.keys(TAB_LABELS) as TabKey[]).map((key) => {
+        const isActive = key === activeTab;
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setActiveTab(key)}
+            style={{
+              borderRadius: '999px',
+              border: '1px solid',
+              borderColor: isActive ? '#2563eb' : '#d1d5db',
+              backgroundColor: isActive ? '#2563eb' : '#f3f4f6',
+              color: isActive ? '#ffffff' : '#1f2937',
+              padding: '0.4rem 1rem',
+              fontWeight: 600,
+              cursor: 'pointer'
+            }}
+          >
+            {TAB_LABELS[key]}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      {renderTabs()}
+
+      {activeTab === 'roster' ? (
+        roster.errorMessage ? (
+          <div className="error-state" style={{ textAlign: 'left' }}>
+            {roster.errorMessage}
+          </div>
+        ) : (
+          <RosterTable
+            sectionId={sectionId}
+            students={roster.students}
+            defaultDate={roster.defaultDate}
+            disabled={roster.disabled}
+            disabledReason={roster.disabledReason}
+          />
+        )
+      ) : null}
+
+      {activeTab === 'lessons' ? (
+        <LessonForm
+          sectionId={sectionId}
+          disabled={lessonForm.disabled}
+          disabledReason={lessonForm.disabledReason}
+        />
+      ) : null}
+
+      {activeTab === 'quizzes' ? (
+        <QuizForm sectionId={sectionId} disabled={quizForm.disabled} disabledReason={quizForm.disabledReason} />
+      ) : null}
+    </div>
+  );
+}

--- a/web/lib/server/internal-api.ts
+++ b/web/lib/server/internal-api.ts
@@ -1,0 +1,75 @@
+import {cookies, headers} from 'next/headers';
+
+function resolveProtocol(host: string, headersList: Headers): string {
+  const forwardedProto = headersList.get('x-forwarded-proto');
+  if (forwardedProto) {
+    return forwardedProto;
+  }
+
+  return host.includes('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https';
+}
+
+export async function internalFetch(path: string, init?: RequestInit): Promise<Response> {
+  const headersList = headers();
+  const cookieStore = cookies();
+
+  const host = headersList.get('x-forwarded-host') ?? headersList.get('host');
+  if (!host) {
+    throw new Error('Missing host header');
+  }
+
+  const protocol = resolveProtocol(host, headersList);
+  const cookieHeader = cookieStore
+    .getAll()
+    .map(({name, value}) => `${name}=${value}`)
+    .join('; ');
+
+  const url = path.startsWith('http') ? path : `${protocol}://${host}${path.startsWith('/') ? path : `/${path}`}`;
+
+  const headersInit = new Headers(init?.headers ?? {});
+  if (cookieHeader && !headersInit.has('cookie')) {
+    headersInit.set('cookie', cookieHeader);
+  }
+
+  if (init?.body && !headersInit.has('content-type')) {
+    headersInit.set('Content-Type', 'application/json');
+  }
+
+  return fetch(url, {
+    ...init,
+    headers: headersInit,
+    cache: 'no-store',
+    next: { revalidate: 0 }
+  });
+}
+
+export async function internalFetchJson<T>(path: string, init?: RequestInit): Promise<{
+  data: T | null;
+  error?: string;
+  status?: number;
+}> {
+  try {
+    const response = await internalFetch(path, init);
+    const contentType = response.headers.get('content-type');
+    const isJson = contentType?.includes('application/json');
+
+    if (!response.ok) {
+      if (isJson) {
+        const body = await response.json().catch(() => ({}));
+        const message = typeof body?.message === 'string' ? body.message : 'Request failed';
+        return { data: null, error: message, status: response.status };
+      }
+
+      return { data: null, error: 'Request failed', status: response.status };
+    }
+
+    if (!isJson) {
+      return { data: null, error: 'Response was not JSON', status: response.status };
+    }
+
+    const data = (await response.json()) as T;
+    return { data, status: response.status };
+  } catch (error) {
+    return { data: null, error: error instanceof Error ? error.message : 'Request failed' };
+  }
+}

--- a/web/lib/teach/auth.ts
+++ b/web/lib/teach/auth.ts
@@ -1,0 +1,42 @@
+import {internalFetch} from '@/lib/server/internal-api';
+import type {CurrentUserResponse} from '@/types/api';
+
+export async function fetchCurrentInstructor(): Promise<{
+  user: CurrentUserResponse | null;
+  status?: number;
+  error?: string;
+}> {
+  try {
+    const response = await internalFetch('/api/auth/me', { method: 'GET' });
+    const contentType = response.headers.get('content-type');
+    const isJson = contentType?.includes('application/json');
+
+    if (!response.ok) {
+      if (isJson) {
+        await response.json().catch(() => ({}));
+      }
+
+      return { user: null, status: response.status, error: 'Unable to load current user' };
+    }
+
+    if (!isJson) {
+      return { user: null, status: response.status, error: 'User response was not JSON' };
+    }
+
+    const data = (await response.json()) as CurrentUserResponse;
+    return { user: data, status: response.status };
+  } catch (error) {
+    return { user: null, error: error instanceof Error ? error.message : 'Unable to load current user' };
+  }
+}
+
+export function hasInstructorAccess(user: CurrentUserResponse | null): boolean {
+  if (!user?.roles?.length) {
+    return false;
+  }
+
+  return user.roles.some((role) => {
+    const lower = role.toLowerCase();
+    return lower === 'instructor' || lower === 'admin';
+  });
+}

--- a/web/lib/teach/normalise.ts
+++ b/web/lib/teach/normalise.ts
@@ -1,0 +1,101 @@
+import {InstructorSection, RosterEntry} from '@/types/teach';
+
+function toArray(payload: unknown): any[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (payload && typeof payload === 'object') {
+    const data = (payload as any).data;
+    const items = (payload as any).items;
+
+    if (Array.isArray(data)) {
+      return data;
+    }
+
+    if (Array.isArray(items)) {
+      return items;
+    }
+  }
+
+  return [];
+}
+
+function toNullableNumber(value: unknown): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : null;
+}
+
+function toStringOrNull(value: unknown): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  return String(value);
+}
+
+function toInstructorSection(raw: any): InstructorSection | null {
+  if (!raw) {
+    return null;
+  }
+
+  const id = raw.id ?? raw.section_id ?? raw.sectionId;
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id: String(id),
+    title: raw.title ?? raw.name ?? null,
+    courseTitle: raw.course?.title ?? raw.courseTitle ?? raw.course_name ?? null,
+    courseCode: raw.course?.code ?? raw.courseCode ?? raw.course_code ?? null,
+    weekday: toNullableNumber(raw.weekday ?? raw.day_of_week ?? raw.dayOfWeek ?? raw.day ?? null),
+    startTime: raw.start_time ?? raw.startTime ?? raw.start ?? null,
+    endTime: raw.end_time ?? raw.endTime ?? raw.end ?? null
+  };
+}
+
+function toRosterEntry(raw: any): RosterEntry | null {
+  if (!raw) {
+    return null;
+  }
+
+  const user = raw.user ?? raw.student ?? {};
+  const userId =
+    user.id ??
+    user.userId ??
+    user.user_id ??
+    raw.userId ??
+    raw.user_id ??
+    raw.studentId ??
+    raw.student_id;
+
+  if (!userId) {
+    return null;
+  }
+
+  return {
+    enrollmentId: toStringOrNull(raw.id ?? raw.enrollmentId ?? raw.enrollment_id ?? null),
+    userId: String(userId),
+    firstName: user.firstName ?? user.first_name ?? raw.firstName ?? raw.first_name ?? null,
+    lastName: user.lastName ?? user.last_name ?? raw.lastName ?? raw.last_name ?? null,
+    displayName: user.displayName ?? user.display_name ?? raw.displayName ?? raw.display_name ?? null,
+    email: user.email ?? raw.email ?? null
+  };
+}
+
+export function normaliseSections(payload: unknown): InstructorSection[] {
+  return toArray(payload)
+    .map((item) => toInstructorSection(item))
+    .filter((section): section is InstructorSection => Boolean(section));
+}
+
+export function normaliseRoster(payload: unknown): RosterEntry[] {
+  return toArray(payload)
+    .map((item) => toRosterEntry(item))
+    .filter((entry): entry is RosterEntry => Boolean(entry));
+}

--- a/web/lib/teach/sections.ts
+++ b/web/lib/teach/sections.ts
@@ -1,0 +1,35 @@
+import {internalFetch} from '@/lib/server/internal-api';
+import {normaliseSections} from '@/lib/teach/normalise';
+import type {InstructorSection} from '@/types/teach';
+
+export async function fetchInstructorSections(): Promise<{
+  sections: InstructorSection[];
+  status?: number;
+  error?: string;
+}> {
+  try {
+    const response = await internalFetch('/api/teach/sections', { method: 'GET' });
+    const contentType = response.headers.get('content-type');
+    const isJson = contentType?.includes('application/json');
+
+    if (!response.ok) {
+      if (isJson) {
+        const body = await response.json().catch(() => ({}));
+        const message = typeof body?.message === 'string' ? body.message : 'Unable to load sections';
+        return { sections: [], status: response.status, error: message };
+      }
+
+      return { sections: [], status: response.status, error: 'Unable to load sections' };
+    }
+
+    if (!isJson) {
+      return { sections: [], status: response.status, error: 'Sections response was not JSON' };
+    }
+
+    const data = await response.json();
+    const sections = normaliseSections(data);
+    return { sections, status: response.status };
+  } catch (error) {
+    return { sections: [], error: error instanceof Error ? error.message : 'Unable to load sections' };
+  }
+}

--- a/web/types/teach.ts
+++ b/web/types/teach.ts
@@ -1,0 +1,18 @@
+export interface InstructorSection {
+  id: string;
+  title?: string | null;
+  courseTitle?: string | null;
+  courseCode?: string | null;
+  weekday?: number | null;
+  startTime?: string | null;
+  endTime?: string | null;
+}
+
+export interface RosterEntry {
+  enrollmentId?: string | null;
+  userId: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  displayName?: string | null;
+  email?: string | null;
+}


### PR DESCRIPTION
## Summary
- add instructor-focused API proxies for sections, roster, attendance, lessons, and quizzes
- introduce reusable teach components for sections, roster management, and lesson/quiz forms
- create instructor portal pages with access control, roster tabs, and graceful fallbacks when the API is unavailable

## Testing
- npm --prefix web run build

------
https://chatgpt.com/codex/tasks/task_e_68d4aa9dc648832f998df8232cba0498