### PR TITLE
Add admin portal for managing seasons and courses

### DIFF
--- a/web/app/admin/courses/[id]/edit/page.tsx
+++ b/web/app/admin/courses/[id]/edit/page.tsx
@@ -1,0 +1,104 @@
+import {notFound} from 'next/navigation';
+
+import {Toolbar} from '@/components/admin/toolbar';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+import {internalFetch} from '@/lib/server/internal';
+
+import {CourseForm} from '../../course-form';
+
+type SeasonOption = {
+  id: string;
+  code: string;
+  title: string;
+};
+
+type CourseResponse = {
+  id: string;
+  code: string;
+  title: string;
+  level?: string | null;
+  modality?: string | null;
+  capacity?: number | null;
+  priceCents?: number | null;
+  currency?: string | null;
+  published?: boolean;
+  seasonId?: string | null;
+  season?: { id?: string; code?: string } | null;
+};
+
+async function fetchSeasonOptions(): Promise<SeasonOption[]> {
+  const response = await internalFetch('/api/admin/seasons', { method: 'GET' });
+  if (!response.ok) {
+    return [];
+  }
+
+  try {
+    const payload = (await response.json()) as SeasonOption[] | { items?: SeasonOption[]; data?: SeasonOption[] };
+    const seasons = Array.isArray(payload)
+      ? payload
+      : payload.items ?? payload.data ?? [];
+    return seasons.map((season) => ({
+      id: season.id ?? season.code,
+      code: season.code,
+      title: season.title
+    }));
+  } catch (error) {
+    return [];
+  }
+}
+
+async function fetchCourse(id: string): Promise<CourseResponse | null> {
+  const response = await internalFetch(`/api/admin/courses/${encodeURIComponent(id)}`, { method: 'GET' });
+  if (!response.ok) {
+    return null;
+  }
+
+  try {
+    return (await response.json()) as CourseResponse;
+  } catch (error) {
+    return null;
+  }
+}
+
+type EditCoursePageProps = {
+  params: { id: string };
+};
+
+export default async function EditCoursePage({ params }: EditCoursePageProps) {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+
+  const [seasons, course] = await Promise.all([fetchSeasonOptions(), fetchCourse(params.id)]);
+
+  if (!course) {
+    notFound();
+  }
+
+  const seasonId = course.seasonId ?? course.season?.id ?? '';
+
+  return (
+    <div>
+      <Toolbar
+        title={t('admin.courses.edit.title', { code: course.code })}
+        description={t('admin.courses.edit.description')}
+      />
+      <CourseForm
+        courseId={course.id}
+        seasons={seasons}
+        submitLabel={t('admin.actions.save')}
+        publishEndpoint={`/api/admin/courses/${course.id}/publish`}
+        initialValues={{
+          seasonId: String(seasonId ?? ''),
+          code: course.code,
+          title: course.title,
+          level: course.level ?? 'A0',
+          modality: course.modality ?? '',
+          capacity: course.capacity ? String(course.capacity) : '',
+          priceCents: course.priceCents ? String(course.priceCents) : '',
+          currency: course.currency ?? 'USD',
+          published: Boolean(course.published)
+        }}
+      />
+    </div>
+  );
+}

--- a/web/app/admin/courses/course-form.tsx
+++ b/web/app/admin/courses/course-form.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import {FormEvent, useMemo, useState} from 'react';
+import {useRouter} from 'next/navigation';
+import {useTranslations} from 'next-intl';
+
+import {CheckboxField, SelectField, TextField} from '@/components/admin/form-fields';
+
+type CourseFormValues = {
+  seasonId: string;
+  code: string;
+  title: string;
+  level: string;
+  modality: string;
+  capacity: string;
+  priceCents: string;
+  currency: string;
+  published: boolean;
+};
+
+type SeasonOption = {
+  id: string;
+  code: string;
+  title: string;
+};
+
+type CourseFormProps = {
+  courseId?: string;
+  seasons: SeasonOption[];
+  initialValues?: Partial<CourseFormValues>;
+  submitLabel?: string;
+  publishEndpoint?: string;
+};
+
+const defaultValues: CourseFormValues = {
+  seasonId: '',
+  code: '',
+  title: '',
+  level: 'A0',
+  modality: '',
+  capacity: '',
+  priceCents: '',
+  currency: 'USD',
+  published: false
+};
+
+export function CourseForm({ courseId, seasons, initialValues, submitLabel, publishEndpoint }: CourseFormProps) {
+  const t = useTranslations('admin');
+  const router = useRouter();
+  const [values, setValues] = useState<CourseFormValues>({
+    ...defaultValues,
+    ...(initialValues ?? {})
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [publishError, setPublishError] = useState<string | null>(null);
+  const [publishing, setPublishing] = useState(false);
+
+  const levelOptions = useMemo(
+    () => ['A0', 'A1', 'A2', 'B1', 'B2'].map((level) => ({ value: level, label: level })),
+    []
+  );
+
+  const seasonOptions = useMemo(
+    () =>
+      seasons.map((season) => ({
+        value: season.id,
+        label: `${season.code} — ${season.title}`
+      })),
+    [seasons]
+  );
+
+  const handleChange = (name: keyof CourseFormValues, value: string | boolean) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const payload = {
+      seasonId: values.seasonId || null,
+      code: values.code,
+      title: values.title,
+      level: values.level,
+      modality: values.modality || null,
+      capacity: values.capacity ? Number(values.capacity) : null,
+      priceCents: values.priceCents ? Number(values.priceCents) : null,
+      currency: values.currency || 'USD',
+      published: values.published
+    };
+
+    const response = await fetch(courseId ? `/api/admin/courses/${courseId}` : '/api/admin/courses', {
+      method: courseId ? 'PATCH' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      setError(data.message ?? t('messages.error'));
+      setSubmitting(false);
+      return;
+    }
+
+    router.push('/admin/courses');
+    router.refresh();
+  };
+
+  const handlePublish = async () => {
+    if (!publishEndpoint) {
+      return;
+    }
+
+    setPublishError(null);
+    setPublishing(true);
+
+    const response = await fetch(publishEndpoint, { method: 'POST' });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      setPublishError(data.message ?? t('messages.error'));
+      setPublishing(false);
+      return;
+    }
+
+    setPublishing(false);
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+      <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+        <SelectField
+          name="seasonId"
+          label={t('courses.fields.season')}
+          value={values.seasonId}
+          onChange={(value) => handleChange('seasonId', value)}
+          options={seasonOptions}
+          placeholder={t('courses.fields.selectSeason')}
+          required
+        />
+        <TextField
+          name="code"
+          label={t('courses.fields.code')}
+          value={values.code}
+          onChange={(value) => handleChange('code', value)}
+          required
+        />
+        <TextField
+          name="title"
+          label={t('courses.fields.title')}
+          value={values.title}
+          onChange={(value) => handleChange('title', value)}
+          required
+        />
+        <SelectField
+          name="level"
+          label={t('courses.fields.level')}
+          value={values.level}
+          onChange={(value) => handleChange('level', value)}
+          options={levelOptions}
+        />
+        <TextField
+          name="modality"
+          label={t('courses.fields.modality')}
+          value={values.modality}
+          onChange={(value) => handleChange('modality', value)}
+        />
+        <TextField
+          name="capacity"
+          label={t('courses.fields.capacity')}
+          value={values.capacity}
+          onChange={(value) => handleChange('capacity', value)}
+          type="number"
+        />
+        <TextField
+          name="priceCents"
+          label={t('courses.fields.priceCents')}
+          value={values.priceCents}
+          onChange={(value) => handleChange('priceCents', value)}
+          type="number"
+        />
+        <TextField
+          name="currency"
+          label={t('courses.fields.currency')}
+          value={values.currency}
+          onChange={(value) => handleChange('currency', value)}
+        />
+      </div>
+      <CheckboxField
+        name="published"
+        label={t('courses.fields.published')}
+        checked={values.published}
+        onChange={(checked) => handleChange('published', checked)}
+      />
+      {error ? <div className="error-state">{error}</div> : null}
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+        <button type="submit" className="button" disabled={submitting}>
+          {submitting ? t('actions.saving') : submitLabel ?? t('actions.save')}
+        </button>
+        {publishEndpoint ? (
+          <button
+            type="button"
+            className="button"
+            onClick={handlePublish}
+            disabled={publishing}
+            style={{ backgroundColor: '#16a34a' }}
+          >
+            {publishing ? t('actions.publishing') : t('actions.publish')}
+          </button>
+        ) : null}
+      </div>
+      {publishError ? <div className="error-state">{publishError}</div> : null}
+    </form>
+  );
+}

--- a/web/app/admin/courses/new/page.tsx
+++ b/web/app/admin/courses/new/page.tsx
@@ -1,0 +1,45 @@
+import {Toolbar} from '@/components/admin/toolbar';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+import {internalFetch} from '@/lib/server/internal';
+
+import {CourseForm} from '../course-form';
+
+type SeasonOption = {
+  id: string;
+  code: string;
+  title: string;
+};
+
+async function fetchSeasonOptions(): Promise<SeasonOption[]> {
+  const response = await internalFetch('/api/admin/seasons', { method: 'GET' });
+  if (!response.ok) {
+    return [];
+  }
+
+  try {
+    const payload = (await response.json()) as SeasonOption[] | { items?: SeasonOption[]; data?: SeasonOption[] };
+    const seasons = Array.isArray(payload)
+      ? payload
+      : payload.items ?? payload.data ?? [];
+    return seasons.map((season) => ({
+      id: season.id ?? season.code,
+      code: season.code,
+      title: season.title
+    }));
+  } catch (error) {
+    return [];
+  }
+}
+
+export default async function NewCoursePage() {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+  const seasons = await fetchSeasonOptions();
+
+  return (
+    <div>
+      <Toolbar title={t('admin.courses.new.title')} description={t('admin.courses.new.description')} />
+      <CourseForm seasons={seasons} submitLabel={t('admin.actions.create')} />
+    </div>
+  );
+}

--- a/web/app/admin/courses/page.tsx
+++ b/web/app/admin/courses/page.tsx
@@ -1,0 +1,250 @@
+import Link from 'next/link';
+
+import {Table, type TableColumn} from '@/components/admin/table';
+import {Toolbar} from '@/components/admin/toolbar';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+import {internalFetch} from '@/lib/server/internal';
+
+import {PublishedToggle} from './published-toggle';
+
+type SeasonOption = {
+  id: string;
+  code: string;
+  title: string;
+};
+
+type CourseListItem = {
+  id: string;
+  code: string;
+  title: string;
+  level?: string | null;
+  priceCents?: number | null;
+  currency?: string | null;
+  published?: boolean;
+  seasonCode?: string | null;
+};
+
+type ListResponse<T> = {
+  data?: T[];
+  items?: T[];
+  meta?: {
+    page?: number;
+    pageCount?: number;
+  };
+};
+
+async function fetchSeasons(): Promise<SeasonOption[]> {
+  const response = await internalFetch('/api/admin/seasons', { method: 'GET' });
+  if (!response.ok) {
+    return [];
+  }
+
+  try {
+    const payload = (await response.json()) as ListResponse<SeasonOption> | SeasonOption[];
+    const seasons = Array.isArray(payload)
+      ? payload
+      : payload.items ?? payload.data ?? [];
+    return seasons.map((season) => ({
+      id: season.id ?? season.code,
+      code: season.code,
+      title: season.title
+    }));
+  } catch (error) {
+    return [];
+  }
+}
+
+function toCourse(item: any): CourseListItem | null {
+  const id = item?.id ?? item?.courseId;
+  const code = item?.code;
+  const title = item?.title;
+  if (!id || !code || !title) {
+    return null;
+  }
+
+  return {
+    id: String(id),
+    code,
+    title,
+    level: item.level ?? item.courseLevel ?? null,
+    priceCents: item.priceCents ?? item.price_cents ?? null,
+    currency: item.currency ?? item.priceCurrency ?? null,
+    published: Boolean(
+      item.published ?? item.isPublished ?? item.status === 'published' ?? item.state === 'published'
+    ),
+    seasonCode: item.season?.code ?? item.seasonCode ?? null
+  };
+}
+
+async function fetchCourses(params: URLSearchParams): Promise<{ courses: CourseListItem[]; meta: { page: number; pageCount: number }; error?: string }> {
+  const query = params.toString();
+  const response = await internalFetch(`/api/admin/courses${query ? `?${query}` : ''}`, { method: 'GET' });
+
+  if (!response.ok) {
+    return { courses: [], meta: { page: 1, pageCount: 1 }, error: `HTTP ${response.status}` };
+  }
+
+  try {
+    const payload = (await response.json()) as ListResponse<any> | any[];
+    const items = Array.isArray(payload) ? payload : payload.items ?? payload.data ?? [];
+    const courses = items
+      .map((item) => toCourse(item))
+      .filter((course): course is CourseListItem => Boolean(course));
+    const meta = Array.isArray(payload)
+      ? { page: 1, pageCount: 1 }
+      : { page: payload.meta?.page ?? 1, pageCount: payload.meta?.pageCount ?? 1 };
+
+    return { courses, meta };
+  } catch (error) {
+    return { courses: [], meta: { page: 1, pageCount: 1 }, error: 'invalid-json' };
+  }
+}
+
+function formatPrice(course: CourseListItem, locale: string): string {
+  if (!course.priceCents) {
+    return '—';
+  }
+
+  const currency = course.currency ?? 'USD';
+  const formatter = new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 0
+  });
+
+  return formatter.format(course.priceCents / 100);
+}
+
+type CoursesPageProps = {
+  searchParams?: Record<string, string | string[]>;
+};
+
+export default async function AdminCoursesPage({ searchParams }: CoursesPageProps) {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+
+  const params = new URLSearchParams();
+  const selectedSeason = Array.isArray(searchParams?.season)
+    ? searchParams?.season[0]
+    : searchParams?.season ?? '';
+
+  if (selectedSeason) {
+    params.set('season', selectedSeason);
+  }
+
+  if (searchParams?.page) {
+    const page = Array.isArray(searchParams.page) ? searchParams.page[0] : searchParams.page;
+    if (page) {
+      params.set('page', page);
+    }
+  }
+
+  const [seasons, { courses, meta, error }] = await Promise.all([
+    fetchSeasons(),
+    fetchCourses(params)
+  ]);
+
+  const columns: TableColumn<CourseListItem>[] = [
+    {
+      key: 'code',
+      header: t('admin.courses.list.code'),
+      render: (course) => course.code
+    },
+    {
+      key: 'title',
+      header: t('admin.courses.list.title'),
+      render: (course) => course.title
+    },
+    {
+      key: 'level',
+      header: t('admin.courses.list.level'),
+      render: (course) => course.level ?? '—'
+    },
+    {
+      key: 'season',
+      header: t('admin.courses.list.season'),
+      render: (course) => course.seasonCode ?? '—'
+    },
+    {
+      key: 'price',
+      header: t('admin.courses.list.price'),
+      render: (course) => formatPrice(course, locale),
+      align: 'right'
+    },
+    {
+      key: 'published',
+      header: t('admin.courses.list.published'),
+      render: (course) => (
+        <PublishedToggle courseId={course.id} initialPublished={Boolean(course.published)} />
+      )
+    },
+    {
+      key: 'actions',
+      header: t('admin.actions.manage'),
+      render: (course) => (
+        <div className="actions">
+          <Link className="button" href={`/admin/courses/${course.id}/edit`} prefetch={false}>
+            {t('admin.actions.edit')}
+          </Link>
+        </div>
+      )
+    }
+  ];
+
+  return (
+    <div>
+      <Toolbar
+        title={t('admin.courses.title')}
+        description={t('admin.courses.description')}
+        actions={
+          <Link className="button" href="/admin/courses/new" prefetch={false}>
+            {t('admin.actions.new')}
+          </Link>
+        }
+      >
+        <form method="get" style={{ display: 'flex', gap: '0.75rem', alignItems: 'flex-end', flexWrap: 'wrap' }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', minWidth: '200px' }}>
+            <span>{t('admin.courses.filter.season')}</span>
+            <select
+              name="season"
+              defaultValue={selectedSeason ?? ''}
+              style={{
+                borderRadius: '0.5rem',
+                border: '1px solid #d1d5db',
+                padding: '0.6rem 0.75rem',
+                background: '#ffffff'
+              }}
+            >
+              <option value="">{t('admin.courses.filter.allSeasons')}</option>
+              {seasons.map((season) => (
+                <option key={season.id} value={season.code}>
+                  {season.code}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="submit" className="button">
+            {t('admin.actions.filter')}
+          </button>
+        </form>
+      </Toolbar>
+      {error ? <div className="error-state">{t('admin.messages.error')}</div> : null}
+      <Table
+        columns={columns}
+        data={courses}
+        emptyMessage={t('admin.messages.noCourses')}
+        pagination={{
+          page: meta.page,
+          pageCount: meta.pageCount,
+          prevHref: meta.page > 1 ? `/admin/courses?season=${selectedSeason}&page=${meta.page - 1}` : undefined,
+          nextHref:
+            meta.page < meta.pageCount
+              ? `/admin/courses?season=${selectedSeason}&page=${meta.page + 1}`
+              : undefined,
+          summary: t('admin.pagination.summary', { page: meta.page, pages: meta.pageCount })
+        }}
+        getRowKey={(course) => course.id}
+      />
+    </div>
+  );
+}

--- a/web/app/admin/courses/published-toggle.tsx
+++ b/web/app/admin/courses/published-toggle.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import {useRouter} from 'next/navigation';
+import {useState} from 'react';
+import {useTranslations} from 'next-intl';
+
+type PublishedToggleProps = {
+  courseId: string;
+  initialPublished: boolean;
+};
+
+export function PublishedToggle({ courseId, initialPublished }: PublishedToggleProps) {
+  const t = useTranslations('admin');
+  const router = useRouter();
+  const [published, setPublished] = useState(initialPublished);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleToggle = async () => {
+    setLoading(true);
+    setError(null);
+    const nextValue = !published;
+
+    const response = await fetch(`/api/admin/courses/${courseId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ published: nextValue })
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      setError(data.message ?? t('messages.error'));
+      setLoading(false);
+      return;
+    }
+
+    setPublished(nextValue);
+    setLoading(false);
+    router.refresh();
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+      <button
+        type="button"
+        onClick={handleToggle}
+        disabled={loading}
+        style={{
+          borderRadius: '999px',
+          border: '1px solid #d1d5db',
+          padding: '0.35rem 0.75rem',
+          backgroundColor: published ? '#2563eb' : '#f3f4f6',
+          color: published ? 'white' : '#1f2937',
+          fontWeight: 600,
+          cursor: 'pointer'
+        }}
+        aria-pressed={published}
+      >
+        {published ? t('courses.published.true') : t('courses.published.false')}
+      </button>
+      {error ? <span style={{ color: '#b91c1c', fontSize: '0.8rem' }}>{error}</span> : null}
+    </div>
+  );
+}

--- a/web/app/admin/layout.tsx
+++ b/web/app/admin/layout.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import type {ReactNode} from 'react';
+
+import {requireRole} from '@/lib/roles';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  await requireRole('admin');
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+
+  const links = [
+    { href: '/admin', label: t('admin.links.overview') },
+    { href: '/admin/seasons', label: t('admin.links.seasons') },
+    { href: '/admin/courses', label: t('admin.links.courses') },
+    { href: '/admin/sections/new', label: t('admin.links.sections') },
+    { href: '/admin/reports/enrollment', label: t('admin.links.reports') }
+  ];
+
+  return (
+    <section style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      <header
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.75rem',
+          padding: '1.25rem 1.5rem',
+          borderRadius: '1rem',
+          backgroundColor: '#111827',
+          color: 'white'
+        }}
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+          <h1 style={{ margin: 0, fontSize: '2rem' }}>{t('admin.title')}</h1>
+          <p style={{ margin: 0, color: 'rgba(255,255,255,0.75)' }}>{t('admin.description')}</p>
+        </div>
+        <nav style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem' }}>
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="button"
+              style={{
+                backgroundColor: 'rgba(255,255,255,0.1)',
+                color: 'white',
+                padding: '0.5rem 0.9rem',
+                borderRadius: '999px',
+                fontWeight: 500
+              }}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </header>
+      <div style={{ background: 'white', borderRadius: '1rem', padding: '1.5rem', boxShadow: '0 10px 25px -20px rgba(15, 23, 42, 0.75)' }}>
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+
+export default async function AdminHomePage() {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+
+  const sections = [
+    {
+      title: t('admin.links.seasons'),
+      description: t('admin.overview.seasons'),
+      href: '/admin/seasons'
+    },
+    {
+      title: t('admin.links.courses'),
+      description: t('admin.overview.courses'),
+      href: '/admin/courses'
+    },
+    {
+      title: t('admin.links.sections'),
+      description: t('admin.overview.sections'),
+      href: '/admin/sections/new'
+    },
+    {
+      title: t('admin.links.reports'),
+      description: t('admin.overview.reports'),
+      href: '/admin/reports/enrollment'
+    }
+  ];
+
+  return (
+    <div className="card-grid">
+      {sections.map((section) => (
+        <article key={section.href} className="card">
+          <h2>{section.title}</h2>
+          <p style={{ margin: 0, color: '#4b5563' }}>{section.description}</p>
+          <footer>
+            <Link className="button" href={section.href} prefetch={false}>
+              {t('admin.actions.view')}
+            </Link>
+          </footer>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/web/app/admin/reports/enrollment/export-csv-button.tsx
+++ b/web/app/admin/reports/enrollment/export-csv-button.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import {useTranslations} from 'next-intl';
+
+export type CsvColumn<Row> = {
+  key: keyof Row;
+  header: string;
+};
+
+type ExportCsvButtonProps<Row extends Record<string, any>> = {
+  rows: Row[];
+  columns: CsvColumn<Row>[];
+  filename: string;
+};
+
+export function ExportCsvButton<Row extends Record<string, any>>({ rows, columns, filename }: ExportCsvButtonProps<Row>) {
+  const t = useTranslations('admin');
+
+  const handleExport = () => {
+    if (!rows.length) {
+      return;
+    }
+
+    const header = columns.map((column) => escapeValue(column.header)).join(',');
+    const body = rows
+      .map((row) => columns.map((column) => escapeValue(row[column.key])).join(','))
+      .join('\n');
+    const csv = `${header}\n${body}`;
+
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', filename);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button type="button" className="button" onClick={handleExport} disabled={!rows.length}>
+      {t('actions.exportCsv')}
+    </button>
+  );
+}
+
+function escapeValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '""';
+  }
+
+  const stringValue = String(value);
+  if (/[",\n]/.test(stringValue)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  return stringValue;
+}

--- a/web/app/admin/reports/enrollment/page.tsx
+++ b/web/app/admin/reports/enrollment/page.tsx
@@ -1,0 +1,229 @@
+import Link from 'next/link';
+
+import {Table, type TableColumn} from '@/components/admin/table';
+import {Toolbar} from '@/components/admin/toolbar';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+import {internalFetch} from '@/lib/server/internal';
+
+import {ExportCsvButton, type CsvColumn} from './export-csv-button';
+
+type SeasonOption = {
+  id: string;
+  code: string;
+  title: string;
+};
+
+type EnrollmentRow = {
+  courseCode: string;
+  title: string;
+  capacity: number | null;
+  active: number | null;
+  pending: number | null;
+  waitlisted: number | null;
+  completed: number | null;
+  cancelled: number | null;
+  seatsLeft: number | null;
+};
+
+async function fetchSeasonOptions(): Promise<SeasonOption[]> {
+  const response = await internalFetch('/api/admin/seasons', { method: 'GET' });
+  if (!response.ok) {
+    return [];
+  }
+
+  try {
+    const payload = (await response.json()) as SeasonOption[] | { items?: SeasonOption[]; data?: SeasonOption[] };
+    const seasons = Array.isArray(payload)
+      ? payload
+      : payload.items ?? payload.data ?? [];
+    return seasons.map((season) => ({
+      id: season.id ?? season.code,
+      code: season.code,
+      title: season.title
+    }));
+  } catch (error) {
+    return [];
+  }
+}
+
+function toRow(item: any): EnrollmentRow | null {
+  const courseCode = item?.courseCode ?? item?.course_code ?? item?.code;
+  const title = item?.title ?? item?.courseTitle ?? item?.course_title;
+  if (!courseCode) {
+    return null;
+  }
+
+  const number = (value: any) => {
+    if (value === null || value === undefined) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
+  return {
+    courseCode: String(courseCode),
+    title: title ?? '',
+    capacity: number(item?.capacity ?? item?.max_capacity ?? item?.limit),
+    active: number(item?.active),
+    pending: number(item?.pending),
+    waitlisted: number(item?.waitlisted),
+    completed: number(item?.completed),
+    cancelled: number(item?.cancelled),
+    seatsLeft: number(item?.seatsLeft ?? item?.seats_left)
+  };
+}
+
+async function fetchReport(seasonCode: string): Promise<{ rows: EnrollmentRow[]; error?: string }> {
+  if (!seasonCode) {
+    return { rows: [] };
+  }
+
+  const response = await internalFetch(`/api/admin/reports/enrollment?season=${encodeURIComponent(seasonCode)}`, {
+    method: 'GET'
+  });
+
+  if (!response.ok) {
+    return { rows: [], error: `HTTP ${response.status}` };
+  }
+
+  try {
+    const payload = (await response.json()) as EnrollmentRow[] | { data?: any[]; items?: any[] };
+    const items = Array.isArray(payload) ? payload : payload.data ?? payload.items ?? [];
+    const rows = items
+      .map((item) => toRow(item))
+      .filter((row): row is EnrollmentRow => Boolean(row));
+    return { rows };
+  } catch (error) {
+    return { rows: [], error: 'invalid-json' };
+  }
+}
+
+type ReportsPageProps = {
+  searchParams?: Record<string, string | string[]>;
+};
+
+export default async function EnrollmentReportsPage({ searchParams }: ReportsPageProps) {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+  const seasons = await fetchSeasonOptions();
+  const selectedSeason = Array.isArray(searchParams?.season)
+    ? searchParams?.season[0]
+    : searchParams?.season ?? '';
+  const { rows, error } = await fetchReport(selectedSeason ?? '');
+
+  const columns: TableColumn<EnrollmentRow>[] = [
+    {
+      key: 'courseCode',
+      header: t('admin.reports.enrollment.columns.code'),
+      render: (row) => row.courseCode
+    },
+    {
+      key: 'title',
+      header: t('admin.reports.enrollment.columns.title'),
+      render: (row) => row.title
+    },
+    {
+      key: 'capacity',
+      header: t('admin.reports.enrollment.columns.capacity'),
+      render: (row) => row.capacity ?? '—',
+      align: 'right'
+    },
+    {
+      key: 'active',
+      header: t('admin.reports.enrollment.columns.active'),
+      render: (row) => row.active ?? 0,
+      align: 'right'
+    },
+    {
+      key: 'pending',
+      header: t('admin.reports.enrollment.columns.pending'),
+      render: (row) => row.pending ?? 0,
+      align: 'right'
+    },
+    {
+      key: 'waitlisted',
+      header: t('admin.reports.enrollment.columns.waitlisted'),
+      render: (row) => row.waitlisted ?? 0,
+      align: 'right'
+    },
+    {
+      key: 'completed',
+      header: t('admin.reports.enrollment.columns.completed'),
+      render: (row) => row.completed ?? 0,
+      align: 'right'
+    },
+    {
+      key: 'cancelled',
+      header: t('admin.reports.enrollment.columns.cancelled'),
+      render: (row) => row.cancelled ?? 0,
+      align: 'right'
+    },
+    {
+      key: 'seatsLeft',
+      header: t('admin.reports.enrollment.columns.seatsLeft'),
+      render: (row) => row.seatsLeft ?? '—',
+      align: 'right'
+    }
+  ];
+
+  const csvColumns: CsvColumn<EnrollmentRow>[] = columns.map((column) => ({
+    key: column.key as keyof EnrollmentRow,
+    header: String(column.header)
+  }));
+
+  return (
+    <div>
+      <Toolbar
+        title={t('admin.reports.enrollment.title')}
+        description={t('admin.reports.enrollment.description')}
+        actions={
+          rows.length ? (
+            <ExportCsvButton
+              rows={rows}
+              columns={csvColumns}
+              filename={`enrollment-${selectedSeason || 'all'}.csv`}
+            />
+          ) : undefined
+        }
+      >
+        <form method="get" style={{ display: 'flex', gap: '0.75rem', alignItems: 'flex-end', flexWrap: 'wrap' }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem', minWidth: '200px' }}>
+            <span>{t('admin.reports.enrollment.filter')}</span>
+            <select
+              name="season"
+              defaultValue={selectedSeason ?? ''}
+              style={{
+                borderRadius: '0.5rem',
+                border: '1px solid #d1d5db',
+                padding: '0.6rem 0.75rem',
+                background: '#ffffff'
+              }}
+            >
+              <option value="">{t('admin.reports.enrollment.allSeasons')}</option>
+              {seasons.map((season) => (
+                <option key={season.id} value={season.code}>
+                  {season.code}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="submit" className="button">
+            {t('admin.actions.filter')}
+          </button>
+        </form>
+      </Toolbar>
+      {error ? <div className="error-state">{t('admin.messages.error')}</div> : null}
+      <Table
+        columns={columns}
+        data={rows}
+        emptyMessage={selectedSeason ? t('admin.reports.enrollment.empty') : t('admin.reports.enrollment.prompt')}
+      />
+      {!rows.length && !selectedSeason ? (
+        <div style={{ marginTop: '1rem', color: '#6b7280' }}>
+          <Link href="/admin/seasons" className="nav-link">
+            {t('admin.reports.enrollment.manageSeasons')}
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/app/admin/seasons/[id]/edit/page.tsx
+++ b/web/app/admin/seasons/[id]/edit/page.tsx
@@ -1,0 +1,67 @@
+import {notFound} from 'next/navigation';
+
+import {Toolbar} from '@/components/admin/toolbar';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+import {internalFetch} from '@/lib/server/internal';
+
+import {SeasonForm} from '../../season-form';
+
+type SeasonResponse = {
+  id: string;
+  code: string;
+  title: string;
+  enrollmentOpen?: string | null;
+  enrollmentClose?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  status?: string | null;
+};
+
+async function fetchSeason(id: string): Promise<SeasonResponse | null> {
+  const response = await internalFetch(`/api/admin/seasons/${encodeURIComponent(id)}`, { method: 'GET' });
+  if (!response.ok) {
+    return null;
+  }
+
+  try {
+    return (await response.json()) as SeasonResponse;
+  } catch (error) {
+    return null;
+  }
+}
+
+type EditSeasonPageProps = {
+  params: { id: string };
+};
+
+export default async function EditSeasonPage({ params }: EditSeasonPageProps) {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+  const season = await fetchSeason(params.id);
+
+  if (!season) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <Toolbar
+        title={t('admin.seasons.edit.title', { code: season.code })}
+        description={t('admin.seasons.edit.description')}
+      />
+      <SeasonForm
+        seasonId={season.id}
+        submitLabel={t('admin.actions.save')}
+        initialValues={{
+          code: season.code,
+          title: season.title,
+          enrollmentOpen: season.enrollmentOpen ?? '',
+          enrollmentClose: season.enrollmentClose ?? '',
+          startDate: season.startDate ?? '',
+          endDate: season.endDate ?? '',
+          status: season.status ?? 'draft'
+        }}
+      />
+    </div>
+  );
+}

--- a/web/app/admin/seasons/new/page.tsx
+++ b/web/app/admin/seasons/new/page.tsx
@@ -1,0 +1,16 @@
+import {Toolbar} from '@/components/admin/toolbar';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+
+import {SeasonForm} from '../season-form';
+
+export default async function NewSeasonPage() {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+
+  return (
+    <div>
+      <Toolbar title={t('admin.seasons.new.title')} description={t('admin.seasons.new.description')} />
+      <SeasonForm submitLabel={t('admin.actions.create')} />
+    </div>
+  );
+}

--- a/web/app/admin/seasons/page.tsx
+++ b/web/app/admin/seasons/page.tsx
@@ -1,0 +1,171 @@
+import Link from 'next/link';
+
+import {Table, type TableColumn} from '@/components/admin/table';
+import {Toolbar} from '@/components/admin/toolbar';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+import {internalFetch} from '@/lib/server/internal';
+
+type SeasonListItem = {
+  id: string;
+  code: string;
+  title: string;
+  status?: string | null;
+  enrollmentOpen?: string | null;
+  enrollmentClose?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+};
+
+type SeasonListResponse = {
+  data?: SeasonListItem[];
+  items?: SeasonListItem[];
+  seasons?: SeasonListItem[];
+  meta?: {
+    page?: number;
+    pageCount?: number;
+  };
+};
+
+async function fetchSeasons(search: string | undefined): Promise<{ seasons: SeasonListItem[]; meta: { page: number; pageCount: number }; error?: string }> {
+  const query = search ? `?${search}` : '';
+  const response = await internalFetch(`/api/admin/seasons${query ? query : ''}`, { method: 'GET' });
+
+  if (!response.ok) {
+    return {
+      seasons: [],
+      meta: { page: 1, pageCount: 1 },
+      error: `HTTP ${response.status}`
+    };
+  }
+
+  let payload: SeasonListResponse | SeasonListItem[] = [];
+
+  try {
+    payload = (await response.json()) as SeasonListResponse | SeasonListItem[];
+  } catch (error) {
+    return { seasons: [], meta: { page: 1, pageCount: 1 }, error: 'invalid-json' };
+  }
+
+  const seasons = Array.isArray(payload)
+    ? payload
+    : payload.seasons ?? payload.items ?? payload.data ?? [];
+  const meta = Array.isArray(payload)
+    ? { page: 1, pageCount: 1 }
+    : {
+        page: payload.meta?.page ?? 1,
+        pageCount: payload.meta?.pageCount ?? 1
+      };
+
+  return { seasons, meta };
+}
+
+function formatDate(value: string | null | undefined, locale: string): string {
+  if (!value) {
+    return '—';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  try {
+    return new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(date);
+  } catch (error) {
+    return value;
+  }
+}
+
+type SeasonsPageProps = {
+  searchParams?: Record<string, string | string[]>;
+};
+
+export default async function AdminSeasonsPage({ searchParams }: SeasonsPageProps) {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+  const search = new URLSearchParams();
+
+  if (searchParams?.page) {
+    const page = Array.isArray(searchParams.page) ? searchParams.page[0] : searchParams.page;
+    if (page) {
+      search.set('page', page);
+    }
+  }
+
+  const { seasons, meta, error } = await fetchSeasons(search.toString());
+
+  const columns: TableColumn<SeasonListItem>[] = [
+    {
+      key: 'code',
+      header: t('admin.seasons.list.code'),
+      render: (season) => season.code
+    },
+    {
+      key: 'title',
+      header: t('admin.seasons.list.title'),
+      render: (season) => season.title
+    },
+    {
+      key: 'status',
+      header: t('admin.seasons.list.status'),
+      render: (season) => season.status ?? t('admin.seasons.status.draft')
+    },
+    {
+      key: 'enrollment',
+      header: t('admin.seasons.list.enrollment'),
+      render: (season) =>
+        t('admin.seasons.list.enrollmentWindow', {
+          start: formatDate(season.enrollmentOpen, locale),
+          end: formatDate(season.enrollmentClose, locale)
+        })
+    },
+    {
+      key: 'dates',
+      header: t('admin.seasons.list.dates'),
+      render: (season) =>
+        t('admin.seasons.list.seasonWindow', {
+          start: formatDate(season.startDate, locale),
+          end: formatDate(season.endDate, locale)
+        })
+    },
+    {
+      key: 'actions',
+      header: t('admin.actions.manage'),
+      render: (season) => (
+        <div className="actions">
+          <Link className="button" href={`/admin/seasons/${season.id}/edit`} prefetch={false}>
+            {t('admin.actions.edit')}
+          </Link>
+        </div>
+      )
+    }
+  ];
+
+  return (
+    <div>
+      <Toolbar
+        title={t('admin.seasons.title')}
+        description={t('admin.seasons.description')}
+        actions={
+          <Link className="button" href="/admin/seasons/new" prefetch={false}>
+            {t('admin.actions.new')}
+          </Link>
+        }
+      />
+      {error ? <div className="error-state">{t('admin.messages.error')}</div> : null}
+      <Table
+        columns={columns}
+        data={seasons}
+        emptyMessage={t('admin.messages.noSeasons')}
+        pagination={{
+          page: meta.page,
+          pageCount: meta.pageCount,
+          prevHref: meta.page > 1 ? `/admin/seasons?page=${meta.page - 1}` : undefined,
+          nextHref: meta.page < meta.pageCount ? `/admin/seasons?page=${meta.page + 1}` : undefined,
+          summary: t('admin.pagination.summary', { page: meta.page, pages: meta.pageCount })
+        }}
+        getRowKey={(season) => season.id ?? season.code}
+      />
+    </div>
+  );
+}

--- a/web/app/admin/seasons/season-form.tsx
+++ b/web/app/admin/seasons/season-form.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import {useRouter} from 'next/navigation';
+import {FormEvent, useMemo, useState} from 'react';
+import {useTranslations} from 'next-intl';
+
+import {DateField, SelectField, TextField} from '@/components/admin/form-fields';
+
+type SeasonFormValues = {
+  code: string;
+  title: string;
+  enrollmentOpen: string;
+  enrollmentClose: string;
+  startDate: string;
+  endDate: string;
+  status: string;
+};
+
+type SeasonFormProps = {
+  seasonId?: string;
+  initialValues?: Partial<SeasonFormValues>;
+  submitLabel?: string;
+};
+
+const defaultValues: SeasonFormValues = {
+  code: '',
+  title: '',
+  enrollmentOpen: '',
+  enrollmentClose: '',
+  startDate: '',
+  endDate: '',
+  status: 'draft'
+};
+
+export function SeasonForm({ seasonId, initialValues, submitLabel }: SeasonFormProps) {
+  const t = useTranslations('admin');
+  const router = useRouter();
+  const [values, setValues] = useState<SeasonFormValues>({
+    ...defaultValues,
+    ...(initialValues ?? {})
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const statusOptions = useMemo(
+    () => [
+      { value: 'draft', label: t('seasons.status.draft') },
+      { value: 'enrolling', label: t('seasons.status.enrolling') },
+      { value: 'running', label: t('seasons.status.running') },
+      { value: 'completed', label: t('seasons.status.completed') },
+      { value: 'archived', label: t('seasons.status.archived') }
+    ],
+    [t]
+  );
+
+  const handleChange = (name: keyof SeasonFormValues, value: string) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const payload = {
+      code: values.code,
+      title: values.title,
+      enrollmentOpen: values.enrollmentOpen || null,
+      enrollmentClose: values.enrollmentClose || null,
+      startDate: values.startDate || null,
+      endDate: values.endDate || null,
+      status: values.status
+    };
+
+    const response = await fetch(seasonId ? `/api/admin/seasons/${seasonId}` : '/api/admin/seasons', {
+      method: seasonId ? 'PATCH' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      setError(data.message ?? t('messages.error'));
+      setSubmitting(false);
+      return;
+    }
+
+    router.push('/admin/seasons');
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+      <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+        <TextField
+          name="code"
+          label={t('seasons.fields.code')}
+          value={values.code}
+          onChange={(value) => handleChange('code', value)}
+          required
+        />
+        <TextField
+          name="title"
+          label={t('seasons.fields.title')}
+          value={values.title}
+          onChange={(value) => handleChange('title', value)}
+          required
+        />
+        <DateField
+          name="enrollmentOpen"
+          label={t('seasons.fields.enrollmentOpen')}
+          value={values.enrollmentOpen ?? ''}
+          onChange={(value) => handleChange('enrollmentOpen', value)}
+        />
+        <DateField
+          name="enrollmentClose"
+          label={t('seasons.fields.enrollmentClose')}
+          value={values.enrollmentClose ?? ''}
+          onChange={(value) => handleChange('enrollmentClose', value)}
+        />
+        <DateField
+          name="startDate"
+          label={t('seasons.fields.startDate')}
+          value={values.startDate ?? ''}
+          onChange={(value) => handleChange('startDate', value)}
+        />
+        <DateField
+          name="endDate"
+          label={t('seasons.fields.endDate')}
+          value={values.endDate ?? ''}
+          onChange={(value) => handleChange('endDate', value)}
+        />
+        <SelectField
+          name="status"
+          label={t('seasons.fields.status')}
+          value={values.status}
+          onChange={(value) => handleChange('status', value)}
+          options={statusOptions}
+        />
+      </div>
+      {error ? <div className="error-state">{error}</div> : null}
+      <button type="submit" className="button" disabled={submitting} style={{ alignSelf: 'flex-start' }}>
+        {submitting ? t('actions.saving') : submitLabel ?? t('actions.save')}
+      </button>
+    </form>
+  );
+}

--- a/web/app/admin/sections/new/page.tsx
+++ b/web/app/admin/sections/new/page.tsx
@@ -1,0 +1,16 @@
+import {Toolbar} from '@/components/admin/toolbar';
+import {detectRequestLocale, getTranslator} from '@/lib/i18n';
+
+import {SectionForm} from './section-form';
+
+export default async function NewSectionPage() {
+  const locale = detectRequestLocale();
+  const t = getTranslator(locale) as any;
+
+  return (
+    <div>
+      <Toolbar title={t('admin.sections.new.title')} description={t('admin.sections.new.description')} />
+      <SectionForm />
+    </div>
+  );
+}

--- a/web/app/admin/sections/new/section-form.tsx
+++ b/web/app/admin/sections/new/section-form.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import {FormEvent, useMemo, useState} from 'react';
+import {useRouter} from 'next/navigation';
+import {useTranslations} from 'next-intl';
+
+import {DateField, SelectField, TextField} from '@/components/admin/form-fields';
+
+type SectionFormValues = {
+  courseId: string;
+  instructorId: string;
+  weekday: string;
+  startTime: string;
+  endTime: string;
+  startDate: string;
+  endDate: string;
+  meetingLink: string;
+};
+
+const defaultValues: SectionFormValues = {
+  courseId: '',
+  instructorId: '',
+  weekday: '',
+  startTime: '',
+  endTime: '',
+  startDate: '',
+  endDate: '',
+  meetingLink: ''
+};
+
+export function SectionForm() {
+  const t = useTranslations('admin');
+  const router = useRouter();
+  const [values, setValues] = useState<SectionFormValues>(defaultValues);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const weekdayOptions = useMemo(
+    () =>
+      ['0', '1', '2', '3', '4', '5', '6'].map((value) => ({
+        value,
+        label: t(`sections.weekdays.${value}`)
+      })),
+    [t]
+  );
+
+  const handleChange = (name: keyof SectionFormValues, value: string) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const payload = {
+      courseId: values.courseId,
+      instructorId: values.instructorId || null,
+      weekday: values.weekday ? Number(values.weekday) : null,
+      startTime: values.startTime || null,
+      endTime: values.endTime || null,
+      startDate: values.startDate || null,
+      endDate: values.endDate || null,
+      meetingLink: values.meetingLink || null
+    };
+
+    const response = await fetch('/api/admin/sections', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      setError(data.message ?? t('messages.error'));
+      setSubmitting(false);
+      return;
+    }
+
+    router.push('/admin/courses');
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+      <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+        <TextField
+          name="courseId"
+          label={t('sections.fields.courseId')}
+          value={values.courseId}
+          onChange={(value) => handleChange('courseId', value)}
+          required
+        />
+        <TextField
+          name="instructorId"
+          label={t('sections.fields.instructorId')}
+          value={values.instructorId}
+          onChange={(value) => handleChange('instructorId', value)}
+        />
+        <SelectField
+          name="weekday"
+          label={t('sections.fields.weekday')}
+          value={values.weekday}
+          onChange={(value) => handleChange('weekday', value)}
+          options={weekdayOptions}
+          placeholder={t('sections.fields.weekdayPlaceholder')}
+        />
+        <TextField
+          name="startTime"
+          label={t('sections.fields.startTime')}
+          value={values.startTime}
+          onChange={(value) => handleChange('startTime', value)}
+          placeholder="09:00"
+        />
+        <TextField
+          name="endTime"
+          label={t('sections.fields.endTime')}
+          value={values.endTime}
+          onChange={(value) => handleChange('endTime', value)}
+          placeholder="11:00"
+        />
+        <DateField
+          name="startDate"
+          label={t('sections.fields.startDate')}
+          value={values.startDate}
+          onChange={(value) => handleChange('startDate', value)}
+        />
+        <DateField
+          name="endDate"
+          label={t('sections.fields.endDate')}
+          value={values.endDate}
+          onChange={(value) => handleChange('endDate', value)}
+        />
+        <TextField
+          name="meetingLink"
+          label={t('sections.fields.meetingLink')}
+          value={values.meetingLink}
+          onChange={(value) => handleChange('meetingLink', value)}
+        />
+      </div>
+      {error ? <div className="error-state">{error}</div> : null}
+      <button type="submit" className="button" disabled={submitting} style={{ alignSelf: 'flex-start' }}>
+        {submitting ? t('actions.saving') : t('actions.createSection')}
+      </button>
+    </form>
+  );
+}

--- a/web/app/api/admin/courses/[id]/publish/route.ts
+++ b/web/app/api/admin/courses/[id]/publish/route.ts
@@ -1,0 +1,35 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+export async function POST(_: NextRequest, { params }: { params: { id: string } }) {
+  const response = await authorizedFetch(`/courses/${encodeURIComponent(params.id)}/publish`, {
+    method: 'POST'
+  });
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json(error, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  if (!isJson) {
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  const data = await response.json();
+  return NextResponse.json(data, { status: response.status });
+}

--- a/web/app/api/admin/courses/[id]/route.ts
+++ b/web/app/api/admin/courses/[id]/route.ts
@@ -1,0 +1,45 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+async function proxy(path: string, init: RequestInit) {
+  const response = await authorizedFetch(path, init);
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json(error, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  if (!isJson) {
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  const data = await response.json();
+  return NextResponse.json(data, { status: response.status });
+}
+
+export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+  return proxy(`/courses/${encodeURIComponent(params.id)}`, { method: 'GET' });
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const body = await request.text();
+  return proxy(`/courses/${encodeURIComponent(params.id)}`, {
+    method: 'PATCH',
+    body: body || undefined
+  });
+}

--- a/web/app/api/admin/courses/route.ts
+++ b/web/app/api/admin/courses/route.ts
@@ -1,0 +1,46 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+async function proxy(path: string, init: RequestInit) {
+  const response = await authorizedFetch(path, init);
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json(error, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  if (!isJson) {
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  const data = await response.json();
+  return NextResponse.json(data, { status: response.status });
+}
+
+export async function GET(request: NextRequest) {
+  const search = request.nextUrl.search;
+  return proxy(`/courses${search}`, { method: 'GET' });
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  return proxy(`/courses`, {
+    method: 'POST',
+    body: body || undefined
+  });
+}

--- a/web/app/api/admin/reports/enrollment/route.ts
+++ b/web/app/api/admin/reports/enrollment/route.ts
@@ -1,0 +1,37 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+export async function GET(request: NextRequest) {
+  const search = request.nextUrl.search;
+  const response = await authorizedFetch(`/reports/enrollment${search}`, {
+    method: 'GET'
+  });
+
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json(error, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  if (!isJson) {
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  const data = await response.json();
+  return NextResponse.json(data, { status: response.status });
+}

--- a/web/app/api/admin/seasons/[id]/route.ts
+++ b/web/app/api/admin/seasons/[id]/route.ts
@@ -1,0 +1,45 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+async function proxy(path: string, init: RequestInit) {
+  const response = await authorizedFetch(path, init);
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json(error, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  if (!isJson) {
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  const data = await response.json();
+  return NextResponse.json(data, { status: response.status });
+}
+
+export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+  return proxy(`/seasons/${encodeURIComponent(params.id)}`, { method: 'GET' });
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const body = await request.text();
+  return proxy(`/seasons/${encodeURIComponent(params.id)}`, {
+    method: 'PATCH',
+    body: body || undefined
+  });
+}

--- a/web/app/api/admin/seasons/route.ts
+++ b/web/app/api/admin/seasons/route.ts
@@ -1,0 +1,46 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+async function proxy(request: NextRequest, path: string, init: RequestInit) {
+  const response = await authorizedFetch(path, init);
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json(error, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  if (!isJson) {
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  const data = await response.json();
+  return NextResponse.json(data, { status: response.status });
+}
+
+export async function GET(request: NextRequest) {
+  const search = request.nextUrl.search;
+  return proxy(request, `/seasons${search}`, { method: 'GET' });
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  return proxy(request, `/seasons`, {
+    method: 'POST',
+    body: body || undefined
+  });
+}

--- a/web/app/api/admin/sections/route.ts
+++ b/web/app/api/admin/sections/route.ts
@@ -1,0 +1,38 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {authorizedFetch} from '@/lib/server/api';
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  const response = await authorizedFetch('/sections', {
+    method: 'POST',
+    body: body || undefined
+  });
+
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+
+  if (!response.ok) {
+    if (isJson) {
+      const error = await response.json().catch(() => ({}));
+      return NextResponse.json(error, { status: response.status });
+    }
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  if (!isJson) {
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: { 'content-type': contentType ?? 'text/plain' }
+    });
+  }
+
+  const data = await response.json();
+  return NextResponse.json(data, { status: response.status });
+}

--- a/web/components/admin/form-fields.tsx
+++ b/web/components/admin/form-fields.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import {ChangeEvent} from 'react';
+
+type BaseFieldProps = {
+  name: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+  placeholder?: string;
+  description?: string;
+};
+
+const labelStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.35rem',
+  fontSize: '0.95rem',
+  fontWeight: 600,
+  color: '#1f2937'
+};
+
+const inputStyle: React.CSSProperties = {
+  borderRadius: '0.5rem',
+  border: '1px solid #d1d5db',
+  padding: '0.6rem 0.75rem',
+  fontSize: '1rem',
+  backgroundColor: '#ffffff'
+};
+
+const descriptionStyle: React.CSSProperties = {
+  fontSize: '0.85rem',
+  fontWeight: 400,
+  color: '#6b7280'
+};
+
+export function TextField({
+  name,
+  label,
+  value,
+  onChange,
+  required,
+  placeholder,
+  description,
+  type = 'text'
+}: BaseFieldProps & { type?: 'text' | 'number' | 'email' | 'password' }) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <label style={labelStyle}>
+      <span>
+        {label}
+        {required ? ' *' : ''}
+      </span>
+      <input
+        id={name}
+        name={name}
+        value={value}
+        onChange={handleChange}
+        required={required}
+        placeholder={placeholder}
+        type={type}
+        style={inputStyle}
+      />
+      {description ? <span style={descriptionStyle}>{description}</span> : null}
+    </label>
+  );
+}
+
+type DateFieldProps = BaseFieldProps & {
+  min?: string;
+  max?: string;
+};
+
+export function DateField({ name, label, value, onChange, required, min, max, description }: DateFieldProps) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <label style={labelStyle}>
+      <span>
+        {label}
+        {required ? ' *' : ''}
+      </span>
+      <input
+        id={name}
+        name={name}
+        type="date"
+        value={value}
+        min={min}
+        max={max}
+        onChange={handleChange}
+        required={required}
+        style={inputStyle}
+      />
+      {description ? <span style={descriptionStyle}>{description}</span> : null}
+    </label>
+  );
+}
+
+type SelectOption = {
+  label: string;
+  value: string;
+};
+
+type SelectFieldProps = BaseFieldProps & {
+  options: SelectOption[];
+};
+
+export function SelectField({
+  name,
+  label,
+  value,
+  onChange,
+  required,
+  options,
+  placeholder,
+  description
+}: SelectFieldProps) {
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <label style={labelStyle}>
+      <span>
+        {label}
+        {required ? ' *' : ''}
+      </span>
+      <select
+        id={name}
+        name={name}
+        value={value}
+        onChange={handleChange}
+        required={required}
+        style={{ ...inputStyle, appearance: 'none' }}
+      >
+        {placeholder ? (
+          <option value="" disabled>
+            {placeholder}
+          </option>
+        ) : null}
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {description ? <span style={descriptionStyle}>{description}</span> : null}
+    </label>
+  );
+}
+
+type CheckboxFieldProps = {
+  name: string;
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  description?: string;
+};
+
+export function CheckboxField({ name, label, checked, onChange, description }: CheckboxFieldProps) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.checked);
+  };
+
+  return (
+    <label style={{ ...labelStyle, flexDirection: 'row', alignItems: 'center' }}>
+      <input
+        id={name}
+        name={name}
+        type="checkbox"
+        checked={checked}
+        onChange={handleChange}
+        style={{ width: '1.25rem', height: '1.25rem' }}
+      />
+      <span style={{ fontWeight: 600 }}>{label}</span>
+      {description ? <span style={descriptionStyle}>{description}</span> : null}
+    </label>
+  );
+}

--- a/web/components/admin/table.tsx
+++ b/web/components/admin/table.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import type {ReactNode} from 'react';
+
+export type TableColumn<T> = {
+  key: string;
+  header: ReactNode;
+  render: (item: T) => ReactNode;
+  align?: 'left' | 'center' | 'right';
+};
+
+export type Pagination = {
+  page: number;
+  pageCount: number;
+  prevHref?: string;
+  nextHref?: string;
+  summary?: ReactNode;
+};
+
+type TableProps<T> = {
+  columns: TableColumn<T>[];
+  data: T[];
+  getRowKey?: (item: T, index: number) => string | number;
+  emptyMessage?: ReactNode;
+  pagination?: Pagination | null;
+};
+
+export function Table<T>({ columns, data, getRowKey, emptyMessage, pagination }: TableProps<T>) {
+  if (!data.length && emptyMessage) {
+    return <div className="empty-state">{emptyMessage}</div>;
+  }
+
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      <table className="list-table">
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th key={column.key} style={{ textAlign: column.align ?? 'left' }}>
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((item, index) => (
+            <tr key={getRowKey ? getRowKey(item, index) : index}>
+              {columns.map((column) => (
+                <td key={column.key} style={{ textAlign: column.align ?? 'left' }}>
+                  {column.render(item)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {pagination ? (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginTop: '1rem',
+            gap: '1rem',
+            flexWrap: 'wrap'
+          }}
+        >
+          {pagination.summary ? (
+            <span style={{ color: '#4b5563', fontSize: '0.9rem' }}>{pagination.summary}</span>
+          ) : (
+            <span />
+          )}
+          <div className="actions">
+            {pagination.prevHref ? (
+              <Link className="button" href={pagination.prevHref} prefetch={false}>
+                &larr;
+              </Link>
+            ) : null}
+            {pagination.nextHref ? (
+              <Link className="button" href={pagination.nextHref} prefetch={false}>
+                &rarr;
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/components/admin/toolbar.tsx
+++ b/web/components/admin/toolbar.tsx
@@ -1,0 +1,38 @@
+import type {ReactNode} from 'react';
+
+type ToolbarProps = {
+  title?: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  children?: ReactNode;
+};
+
+export function Toolbar({ title, description, actions, children }: ToolbarProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+        marginBottom: '1.5rem'
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: '1rem'
+        }}
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+          {title ? <h1 style={{ margin: 0, fontSize: '1.8rem' }}>{title}</h1> : null}
+          {description ? <span style={{ color: '#6b7280' }}>{description}</span> : null}
+        </div>
+        {actions ? <div className="actions">{actions}</div> : null}
+      </div>
+      {children ? <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>{children}</div> : null}
+    </div>
+  );
+}

--- a/web/lib/roles.ts
+++ b/web/lib/roles.ts
@@ -1,0 +1,39 @@
+import {redirect} from 'next/navigation';
+
+import type {CurrentUserResponse} from '@/types/api';
+import {internalFetch} from '@/lib/server/internal';
+
+type RequireRoleOptions = {
+  redirectTo?: string;
+  fallback?: () => never | Promise<never>;
+};
+
+export async function requireRole(role: string, options?: RequireRoleOptions): Promise<CurrentUserResponse> {
+  const response = await internalFetch('/api/auth/me', { method: 'GET' });
+
+  if (!response.ok) {
+    if (options?.fallback) {
+      await options.fallback();
+    }
+
+    redirect(options?.redirectTo ?? '/auth/login');
+  }
+
+  let user: CurrentUserResponse | null = null;
+
+  try {
+    user = (await response.json()) as CurrentUserResponse;
+  } catch (error) {
+    user = null;
+  }
+
+  if (!user || !Array.isArray(user.roles) || !user.roles.includes(role)) {
+    if (options?.fallback) {
+      await options.fallback();
+    }
+
+    redirect(options?.redirectTo ?? '/auth/login');
+  }
+
+  return user;
+}

--- a/web/lib/server/internal.ts
+++ b/web/lib/server/internal.ts
@@ -1,0 +1,59 @@
+import {cookies, headers} from 'next/headers';
+
+function resolveProtocol(host: string | null, headersList: Headers): string {
+  const forwardedProto = headersList.get('x-forwarded-proto');
+  if (forwardedProto) {
+    return forwardedProto.split(',')[0]!.trim();
+  }
+
+  if (host && host.includes('localhost')) {
+    return 'http';
+  }
+
+  return 'https';
+}
+
+export function getInternalBaseUrl(): string | null {
+  const headersList = headers();
+  const host = headersList.get('x-forwarded-host') ?? headersList.get('host');
+
+  if (!host) {
+    return null;
+  }
+
+  const protocol = resolveProtocol(host, headersList);
+  return `${protocol}://${host}`;
+}
+
+export async function internalFetch(path: string, init?: RequestInit): Promise<Response> {
+  const baseUrl = getInternalBaseUrl();
+
+  if (!baseUrl) {
+    return new Response('Unable to determine base URL', { status: 500 });
+  }
+
+  const url = path.startsWith('http') ? path : `${baseUrl}${path}`;
+  const cookieStore = cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map(({ name, value }) => `${name}=${value}`)
+    .join('; ');
+
+  const headersInit = new Headers(init?.headers);
+  if (cookieHeader) {
+    headersInit.set('cookie', cookieHeader);
+  }
+
+  if (!headersInit.has('accept')) {
+    headersInit.set('accept', 'application/json');
+  }
+
+  const response = await fetch(url, {
+    ...init,
+    headers: headersInit,
+    cache: 'no-store',
+    next: { revalidate: 0 }
+  });
+
+  return response;
+}

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -87,5 +87,169 @@
     "4": "الخميس",
     "5": "الجمعة",
     "6": "السبت"
+  },
+  "admin": {
+    "title": "بوابة الإدارة",
+    "description": "إدارة المواسم والدورات والشُعب والتقارير.",
+    "links": {
+      "overview": "نظرة عامة",
+      "seasons": "المواسم",
+      "courses": "الدورات",
+      "sections": "الشُعب",
+      "reports": "التقارير"
+    },
+    "overview": {
+      "seasons": "إعداد فترات التسجيل ومواعيد الموسم.",
+      "courses": "إنشاء العروض لكل مستوى ونمط.",
+      "sections": "جدولة المعلمين وأوقات اللقاء.",
+      "reports": "مراجعة أداء التسجيل لكل دورة."
+    },
+    "actions": {
+      "view": "عرض",
+      "manage": "إجراءات",
+      "edit": "تعديل",
+      "new": "جديد",
+      "create": "إنشاء",
+      "save": "حفظ",
+      "saving": "جارٍ الحفظ…",
+      "publish": "نشر",
+      "publishing": "جارٍ النشر…",
+      "filter": "تصفية",
+      "exportCsv": "تصدير CSV",
+      "createSection": "إنشاء شعبة"
+    },
+    "messages": {
+      "error": "تعذر إتمام هذا الطلب. يرجى المحاولة مرة أخرى.",
+      "noSeasons": "لا توجد مواسم.",
+      "noCourses": "لا توجد دورات."
+    },
+    "pagination": {
+      "summary": "الصفحة {page} من {pages}"
+    },
+    "seasons": {
+      "title": "المواسم",
+      "description": "عرض وتحديث فترات التسجيل لكل موسم.",
+      "list": {
+        "code": "الرمز",
+        "title": "العنوان",
+        "status": "الحالة",
+        "enrollment": "التسجيل",
+        "dates": "التواريخ",
+        "enrollmentWindow": "{start} – {end}",
+        "seasonWindow": "{start} – {end}"
+      },
+      "status": {
+        "draft": "مسودة",
+        "enrolling": "قيد التسجيل",
+        "running": "قيد التنفيذ",
+        "completed": "منتهٍ",
+        "archived": "مؤرشف"
+      },
+      "fields": {
+        "code": "رمز الموسم",
+        "title": "العنوان",
+        "enrollmentOpen": "بداية التسجيل",
+        "enrollmentClose": "نهاية التسجيل",
+        "startDate": "تاريخ البدء",
+        "endDate": "تاريخ الانتهاء",
+        "status": "الحالة"
+      },
+      "new": {
+        "title": "إنشاء موسم",
+        "description": "حدد فترات التسجيل وتشغيل الموسم الجديد."
+      },
+      "edit": {
+        "title": "تعديل موسم {code}",
+        "description": "تحديث الإعدادات الزمنية والتسجيل."
+      }
+    },
+    "courses": {
+      "title": "الدورات",
+      "description": "إدارة الدورات لكل موسم.",
+      "list": {
+        "code": "الرمز",
+        "title": "العنوان",
+        "level": "المستوى",
+        "season": "الموسم",
+        "price": "السعر",
+        "published": "منشور"
+      },
+      "filter": {
+        "season": "الموسم",
+        "allSeasons": "كل المواسم"
+      },
+      "fields": {
+        "season": "الموسم",
+        "selectSeason": "اختر موسمًا",
+        "code": "رمز الدورة",
+        "title": "العنوان",
+        "level": "المستوى",
+        "modality": "نمط التعلم",
+        "capacity": "الطاقة الاستيعابية",
+        "priceCents": "السعر (بالفلس)",
+        "currency": "العملة",
+        "published": "منشور"
+      },
+      "new": {
+        "title": "إنشاء دورة",
+        "description": "أضف دورة جديدة إلى موسم."
+      },
+      "edit": {
+        "title": "تعديل دورة {code}",
+        "description": "عدّل التفاصيل والطاقة وحالة النشر."
+      },
+      "published": {
+        "true": "منشور",
+        "false": "مسودة"
+      }
+    },
+    "sections": {
+      "new": {
+        "title": "إنشاء شعبة",
+        "description": "جدولة شعبة جديدة لهذه الدورة."
+      },
+      "fields": {
+        "courseId": "معرّف الدورة",
+        "instructorId": "معرّف المدرس",
+        "weekday": "اليوم",
+        "weekdayPlaceholder": "اختر اليوم",
+        "startTime": "وقت البدء",
+        "endTime": "وقت الانتهاء",
+        "startDate": "تاريخ البدء",
+        "endDate": "تاريخ الانتهاء",
+        "meetingLink": "رابط اللقاء"
+      },
+      "weekdays": {
+        "0": "الأحد",
+        "1": "الاثنين",
+        "2": "الثلاثاء",
+        "3": "الأربعاء",
+        "4": "الخميس",
+        "5": "الجمعة",
+        "6": "السبت"
+      }
+    },
+    "reports": {
+      "enrollment": {
+        "title": "تقرير التسجيل",
+        "description": "تتبع حالات التسجيل لكل دورة.",
+        "filter": "الموسم",
+        "allSeasons": "اختر موسمًا",
+        "columns": {
+          "code": "الدورة",
+          "title": "العنوان",
+          "capacity": "الطاقة",
+          "active": "نشط",
+          "pending": "معلق",
+          "waitlisted": "قائمة الانتظار",
+          "completed": "مكتمل",
+          "cancelled": "ملغى",
+          "seatsLeft": "المقاعد المتبقية"
+        },
+        "empty": "لا توجد بيانات تسجيل لهذا الموسم.",
+        "prompt": "اختر موسمًا لعرض أعداد التسجيل.",
+        "manageSeasons": "إدارة المواسم"
+      }
+    }
   }
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -87,5 +87,169 @@
     "4": "Thursday",
     "5": "Friday",
     "6": "Saturday"
+  },
+  "admin": {
+    "title": "Admin portal",
+    "description": "Manage seasons, courses, sections, and reports.",
+    "links": {
+      "overview": "Overview",
+      "seasons": "Seasons",
+      "courses": "Courses",
+      "sections": "Sections",
+      "reports": "Reports"
+    },
+    "overview": {
+      "seasons": "Configure enrollment windows and term dates.",
+      "courses": "Create offerings for each level and modality.",
+      "sections": "Schedule instructors and meeting times.",
+      "reports": "Review enrollment performance by course."
+    },
+    "actions": {
+      "view": "View",
+      "manage": "Actions",
+      "edit": "Edit",
+      "new": "New",
+      "create": "Create",
+      "save": "Save",
+      "saving": "Saving…",
+      "publish": "Publish",
+      "publishing": "Publishing…",
+      "filter": "Filter",
+      "exportCsv": "Export CSV",
+      "createSection": "Create section"
+    },
+    "messages": {
+      "error": "We couldn't complete this request. Please try again.",
+      "noSeasons": "No seasons found.",
+      "noCourses": "No courses found."
+    },
+    "pagination": {
+      "summary": "Page {page} of {pages}"
+    },
+    "seasons": {
+      "title": "Seasons",
+      "description": "View and update enrollment periods for each season.",
+      "list": {
+        "code": "Code",
+        "title": "Title",
+        "status": "Status",
+        "enrollment": "Enrollment",
+        "dates": "Dates",
+        "enrollmentWindow": "{start} – {end}",
+        "seasonWindow": "{start} – {end}"
+      },
+      "status": {
+        "draft": "Draft",
+        "enrolling": "Enrolling",
+        "running": "Running",
+        "completed": "Completed",
+        "archived": "Archived"
+      },
+      "fields": {
+        "code": "Season code",
+        "title": "Title",
+        "enrollmentOpen": "Enrollment opens",
+        "enrollmentClose": "Enrollment closes",
+        "startDate": "Start date",
+        "endDate": "End date",
+        "status": "Status"
+      },
+      "new": {
+        "title": "Create season",
+        "description": "Define the enrollment and run dates for a new season."
+      },
+      "edit": {
+        "title": "Edit season {code}",
+        "description": "Update schedule and enrollment settings."
+      }
+    },
+    "courses": {
+      "title": "Courses",
+      "description": "Manage course inventory by season.",
+      "list": {
+        "code": "Code",
+        "title": "Title",
+        "level": "Level",
+        "season": "Season",
+        "price": "Price",
+        "published": "Published"
+      },
+      "filter": {
+        "season": "Season",
+        "allSeasons": "All seasons"
+      },
+      "fields": {
+        "season": "Season",
+        "selectSeason": "Select a season",
+        "code": "Course code",
+        "title": "Title",
+        "level": "Level",
+        "modality": "Modality",
+        "capacity": "Capacity",
+        "priceCents": "Price (cents)",
+        "currency": "Currency",
+        "published": "Published"
+      },
+      "new": {
+        "title": "Create course",
+        "description": "Add a new course to a season."
+      },
+      "edit": {
+        "title": "Edit course {code}",
+        "description": "Adjust details, capacity, and publication state."
+      },
+      "published": {
+        "true": "Published",
+        "false": "Draft"
+      }
+    },
+    "sections": {
+      "new": {
+        "title": "Create section",
+        "description": "Schedule a new teaching section for a course."
+      },
+      "fields": {
+        "courseId": "Course ID",
+        "instructorId": "Instructor ID",
+        "weekday": "Weekday",
+        "weekdayPlaceholder": "Select weekday",
+        "startTime": "Start time",
+        "endTime": "End time",
+        "startDate": "Start date",
+        "endDate": "End date",
+        "meetingLink": "Meeting link"
+      },
+      "weekdays": {
+        "0": "Sunday",
+        "1": "Monday",
+        "2": "Tuesday",
+        "3": "Wednesday",
+        "4": "Thursday",
+        "5": "Friday",
+        "6": "Saturday"
+      }
+    },
+    "reports": {
+      "enrollment": {
+        "title": "Enrollment report",
+        "description": "Track enrollment status counts per course.",
+        "filter": "Season",
+        "allSeasons": "Select season",
+        "columns": {
+          "code": "Course",
+          "title": "Title",
+          "capacity": "Capacity",
+          "active": "Active",
+          "pending": "Pending",
+          "waitlisted": "Waitlisted",
+          "completed": "Completed",
+          "cancelled": "Cancelled",
+          "seatsLeft": "Seats left"
+        },
+        "empty": "No enrollment data for this season.",
+        "prompt": "Choose a season to view enrollment totals.",
+        "manageSeasons": "Manage seasons"
+      }
+    }
   }
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -87,5 +87,169 @@
     "4": "木曜",
     "5": "金曜",
     "6": "土曜"
+  },
+  "admin": {
+    "title": "管理ポータル",
+    "description": "シーズン・講座・クラス・レポートを管理します。",
+    "links": {
+      "overview": "概要",
+      "seasons": "シーズン",
+      "courses": "講座",
+      "sections": "クラス",
+      "reports": "レポート"
+    },
+    "overview": {
+      "seasons": "申込期間と開講期間を設定します。",
+      "courses": "レベルや形式ごとの講座を登録します。",
+      "sections": "講師と開催スケジュールを設定します。",
+      "reports": "講座ごとの申込状況を確認します。"
+    },
+    "actions": {
+      "view": "表示",
+      "manage": "操作",
+      "edit": "編集",
+      "new": "新規",
+      "create": "作成",
+      "save": "保存",
+      "saving": "保存中…",
+      "publish": "公開",
+      "publishing": "公開中…",
+      "filter": "絞り込み",
+      "exportCsv": "CSV をエクスポート",
+      "createSection": "クラスを作成"
+    },
+    "messages": {
+      "error": "リクエストを完了できませんでした。もう一度お試しください。",
+      "noSeasons": "シーズンが見つかりません。",
+      "noCourses": "講座が見つかりません。"
+    },
+    "pagination": {
+      "summary": "ページ {page} / {pages}"
+    },
+    "seasons": {
+      "title": "シーズン",
+      "description": "各シーズンの申込期間を確認・更新します。",
+      "list": {
+        "code": "コード",
+        "title": "名称",
+        "status": "状態",
+        "enrollment": "申込期間",
+        "dates": "開講期間",
+        "enrollmentWindow": "{start} 〜 {end}",
+        "seasonWindow": "{start} 〜 {end}"
+      },
+      "status": {
+        "draft": "下書き",
+        "enrolling": "受付中",
+        "running": "開講中",
+        "completed": "終了",
+        "archived": "アーカイブ"
+      },
+      "fields": {
+        "code": "シーズンコード",
+        "title": "名称",
+        "enrollmentOpen": "申込開始日",
+        "enrollmentClose": "申込終了日",
+        "startDate": "開講日",
+        "endDate": "終了日",
+        "status": "状態"
+      },
+      "new": {
+        "title": "シーズンを作成",
+        "description": "新しいシーズンの申込期間と開講期間を設定します。"
+      },
+      "edit": {
+        "title": "シーズン {code} を編集",
+        "description": "スケジュールと申込設定を更新します。"
+      }
+    },
+    "courses": {
+      "title": "講座",
+      "description": "シーズン別の講座を管理します。",
+      "list": {
+        "code": "コード",
+        "title": "名称",
+        "level": "レベル",
+        "season": "シーズン",
+        "price": "価格",
+        "published": "公開状況"
+      },
+      "filter": {
+        "season": "シーズン",
+        "allSeasons": "すべて"
+      },
+      "fields": {
+        "season": "シーズン",
+        "selectSeason": "シーズンを選択",
+        "code": "講座コード",
+        "title": "名称",
+        "level": "レベル",
+        "modality": "開催形式",
+        "capacity": "定員",
+        "priceCents": "価格（セント）",
+        "currency": "通貨",
+        "published": "公開済み"
+      },
+      "new": {
+        "title": "講座を作成",
+        "description": "シーズンに講座を追加します。"
+      },
+      "edit": {
+        "title": "講座 {code} を編集",
+        "description": "詳細・定員・公開状態を更新します。"
+      },
+      "published": {
+        "true": "公開",
+        "false": "下書き"
+      }
+    },
+    "sections": {
+      "new": {
+        "title": "クラスを作成",
+        "description": "講座のクラススケジュールを登録します。"
+      },
+      "fields": {
+        "courseId": "講座 ID",
+        "instructorId": "講師 ID",
+        "weekday": "曜日",
+        "weekdayPlaceholder": "曜日を選択",
+        "startTime": "開始時間",
+        "endTime": "終了時間",
+        "startDate": "開始日",
+        "endDate": "終了日",
+        "meetingLink": "ミーティング URL"
+      },
+      "weekdays": {
+        "0": "日曜",
+        "1": "月曜",
+        "2": "火曜",
+        "3": "水曜",
+        "4": "木曜",
+        "5": "金曜",
+        "6": "土曜"
+      }
+    },
+    "reports": {
+      "enrollment": {
+        "title": "申込レポート",
+        "description": "講座ごとの申込状況を確認します。",
+        "filter": "シーズン",
+        "allSeasons": "シーズンを選択",
+        "columns": {
+          "code": "講座",
+          "title": "名称",
+          "capacity": "定員",
+          "active": "有効",
+          "pending": "保留",
+          "waitlisted": "待機",
+          "completed": "完了",
+          "cancelled": "キャンセル",
+          "seatsLeft": "残席"
+        },
+        "empty": "このシーズンの申込データはありません。",
+        "prompt": "シーズンを選択すると申込数が表示されます。",
+        "manageSeasons": "シーズンを管理"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- implement server-side admin role guard and helper for authenticated internal API calls
- add Next.js API proxies for admin CRUD, publishing, sections, and enrollment report endpoints
- build admin portal pages with shared form/table components and localized labels for seasons, courses, sections, and reports

## Testing
- npm --prefix web run build

------
https://chatgpt.com/codex/tasks/task_e_68d4aab89968832fb2fddd3abba7d991