### PR TITLE
Add Flutter auth flow with secure token handling

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,12 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub-cache/
+build/
+
+# Visual Studio Code
+.vscode/
+
+# IntelliJ
+.idea/
+*.iml

--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: true
+    prefer_single_quotes: true

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'core/network/dio_provider.dart';
+import 'features/auth/logic/auth_notifier.dart';
+import 'features/auth/ui/login_page.dart';
+import 'features/home/ui/home_page.dart';
+import 'features/home/ui/dashboard_page.dart';
+
+class IrohaApp extends ConsumerWidget {
+  const IrohaApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(dioProvider); // ensure provider initialized early
+
+    return MaterialApp(
+      title: 'iroha',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+        useMaterial3: true,
+      ),
+      initialRoute: '/',
+      routes: {
+        '/': (_) => const HomePage(),
+        '/login': (_) => const LoginPage(),
+        '/dashboard': (_) => const DashboardPage(),
+      },
+    );
+  }
+}

--- a/mobile/lib/core/config/api_config.dart
+++ b/mobile/lib/core/config/api_config.dart
@@ -1,0 +1,1 @@
+const apiBase = String.fromEnvironment('API_BASE_URL', defaultValue: 'http://localhost:3000');

--- a/mobile/lib/core/network/dio_provider.dart
+++ b/mobile/lib/core/network/dio_provider.dart
@@ -1,0 +1,90 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../config/api_config.dart';
+import '../../features/auth/data/token_store.dart';
+
+final dioProvider = Provider<Dio>((ref) {
+  final tokenStore = ref.watch(tokenStoreProvider);
+
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: apiBase,
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 15),
+    ),
+  );
+
+  dio.interceptors.add(
+    QueuedInterceptorsWrapper(
+      onRequest: (options, handler) async {
+        if (options.extra['skipAuth'] == true) {
+          handler.next(options);
+          return;
+        }
+        final accessToken = await tokenStore.readAccessToken();
+        if (accessToken != null && accessToken.isNotEmpty) {
+          options.headers['Authorization'] = 'Bearer $accessToken';
+        }
+        handler.next(options);
+      },
+      onError: (error, handler) async {
+        final response = error.response;
+        if (error.requestOptions.extra['skipAuth'] == true) {
+          handler.next(error);
+          return;
+        }
+        if (response?.statusCode != 401 || error.requestOptions.extra['retried'] == true) {
+          handler.next(error);
+          return;
+        }
+        final refreshToken = await tokenStore.readRefreshToken();
+        if (refreshToken == null || refreshToken.isEmpty) {
+          await tokenStore.clearTokens();
+          handler.next(error);
+          return;
+        }
+
+        try {
+          final refreshDio = Dio(
+            BaseOptions(
+              baseUrl: apiBase,
+              connectTimeout: const Duration(seconds: 10),
+              receiveTimeout: const Duration(seconds: 15),
+            ),
+          );
+          final refreshResponse = await refreshDio.post<Map<String, dynamic>>(
+            '/auth/refresh',
+            data: {'refreshToken': refreshToken},
+          );
+          final data = refreshResponse.data ?? <String, dynamic>{};
+          final newAccessToken = data['accessToken'] as String?;
+          final newRefreshToken = data['refreshToken'] as String?;
+          if (newAccessToken == null || newRefreshToken == null) {
+            await tokenStore.clearTokens();
+            handler.next(error);
+            return;
+          }
+          await tokenStore.saveTokens(accessToken: newAccessToken, refreshToken: newRefreshToken);
+
+          final requestOptions = error.requestOptions;
+          requestOptions.headers['Authorization'] = 'Bearer $newAccessToken';
+          requestOptions.extra = {
+            ...requestOptions.extra,
+            'retried': true,
+          };
+          final retryResponse = await dio.fetch(requestOptions);
+          handler.resolve(retryResponse);
+        } on DioException {
+          await tokenStore.clearTokens();
+          handler.next(error);
+        } catch (_) {
+          await tokenStore.clearTokens();
+          handler.next(error);
+        }
+      },
+    ),
+  );
+
+  return dio;
+});

--- a/mobile/lib/features/auth/data/auth_api.dart
+++ b/mobile/lib/features/auth/data/auth_api.dart
@@ -1,0 +1,83 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/dio_provider.dart';
+import '../domain/user.dart';
+import 'token_store.dart';
+
+class AuthTokens {
+  const AuthTokens({required this.accessToken, required this.refreshToken});
+
+  final String accessToken;
+  final String refreshToken;
+}
+
+class LoginResponse {
+  const LoginResponse({required this.tokens, required this.user});
+
+  final AuthTokens tokens;
+  final User user;
+}
+
+final authApiProvider = Provider<AuthApi>((ref) {
+  final dio = ref.watch(dioProvider);
+  final store = ref.watch(tokenStoreProvider);
+  return AuthApi(dio, store);
+});
+
+class AuthApi {
+  AuthApi(this._dio, this._tokenStore);
+
+  final Dio _dio;
+  final TokenStore _tokenStore;
+
+  Future<LoginResponse> login({required String email, required String password}) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/auth/login',
+      data: {'email': email, 'password': password},
+      options: Options(extra: {'skipAuth': true}),
+    );
+
+    final data = response.data ?? <String, dynamic>{};
+    final accessToken = data['accessToken'] as String?;
+    final refreshToken = data['refreshToken'] as String?;
+    final userJson = data['user'] as Map<String, dynamic>?;
+
+    if (accessToken == null || refreshToken == null || userJson == null) {
+      throw DioException(
+        requestOptions: response.requestOptions,
+        message: 'Invalid login response.',
+      );
+    }
+
+    final user = User.fromJson(userJson);
+    final tokens = AuthTokens(accessToken: accessToken, refreshToken: refreshToken);
+    await _tokenStore.saveTokens(accessToken: accessToken, refreshToken: refreshToken);
+    return LoginResponse(tokens: tokens, user: user);
+  }
+
+  Future<AuthTokens> refresh({required String refreshToken}) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/auth/refresh',
+      data: {'refreshToken': refreshToken},
+      options: Options(extra: {'skipAuth': true}),
+    );
+    final data = response.data ?? <String, dynamic>{};
+    final accessToken = data['accessToken'] as String?;
+    final newRefreshToken = data['refreshToken'] as String?;
+    if (accessToken == null || newRefreshToken == null) {
+      throw DioException(
+        requestOptions: response.requestOptions,
+        message: 'Invalid refresh response.',
+      );
+    }
+    await _tokenStore.saveTokens(accessToken: accessToken, refreshToken: newRefreshToken);
+    return AuthTokens(accessToken: accessToken, refreshToken: newRefreshToken);
+  }
+
+  Future<User> me() async {
+    final response = await _dio.get<Map<String, dynamic>>('/me');
+    final data = response.data ?? <String, dynamic>{};
+    return User.fromJson(data);
+  }
+}

--- a/mobile/lib/features/auth/data/token_store.dart
+++ b/mobile/lib/features/auth/data/token_store.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+final flutterSecureStorageProvider = Provider<FlutterSecureStorage>((ref) {
+  return const FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+    iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+  );
+});
+
+final tokenStoreProvider = Provider<TokenStore>((ref) {
+  final storage = ref.watch(flutterSecureStorageProvider);
+  return TokenStore(storage);
+});
+
+class TokenStore {
+  TokenStore(this._storage);
+
+  static const _accessTokenKey = 'accessToken';
+  static const _refreshTokenKey = 'refreshToken';
+
+  final FlutterSecureStorage _storage;
+
+  Future<void> saveTokens({required String accessToken, required String refreshToken}) async {
+    await _storage.write(key: _accessTokenKey, value: accessToken);
+    await _storage.write(key: _refreshTokenKey, value: refreshToken);
+  }
+
+  Future<String?> readAccessToken() {
+    return _storage.read(key: _accessTokenKey);
+  }
+
+  Future<String?> readRefreshToken() {
+    return _storage.read(key: _refreshTokenKey);
+  }
+
+  Future<void> clearTokens() async {
+    await _storage.delete(key: _accessTokenKey);
+    await _storage.delete(key: _refreshTokenKey);
+  }
+}

--- a/mobile/lib/features/auth/domain/user.dart
+++ b/mobile/lib/features/auth/domain/user.dart
@@ -1,0 +1,26 @@
+class User {
+  const User({required this.id, required this.email, this.firstName, this.lastName});
+
+  factory User.fromJson(Map<String, dynamic> json) {
+    return User(
+      id: json['id']?.toString() ?? '',
+      email: json['email'] as String? ?? '',
+      firstName: json['firstName'] as String?,
+      lastName: json['lastName'] as String?,
+    );
+  }
+
+  final String id;
+  final String email;
+  final String? firstName;
+  final String? lastName;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'email': email,
+      if (firstName != null) 'firstName': firstName,
+      if (lastName != null) 'lastName': lastName,
+    };
+  }
+}

--- a/mobile/lib/features/auth/logic/auth_notifier.dart
+++ b/mobile/lib/features/auth/logic/auth_notifier.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/auth_api.dart';
+import '../data/token_store.dart';
+import '../domain/user.dart';
+
+sealed class AuthState {
+  const AuthState();
+}
+
+class AuthStateUnauthenticated extends AuthState {
+  const AuthStateUnauthenticated();
+}
+
+class AuthStateAuthenticating extends AuthState {
+  const AuthStateAuthenticating();
+}
+
+class AuthStateAuthenticated extends AuthState {
+  const AuthStateAuthenticated(this.user);
+
+  final User user;
+}
+
+final authNotifierProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {
+  final api = ref.watch(authApiProvider);
+  final store = ref.watch(tokenStoreProvider);
+  return AuthNotifier(api: api, tokenStore: store)..restoreSession();
+});
+
+class AuthNotifier extends StateNotifier<AuthState> {
+  AuthNotifier({required AuthApi api, required TokenStore tokenStore})
+      : _api = api,
+        _tokenStore = tokenStore,
+        super(const AuthStateUnauthenticated());
+
+  final AuthApi _api;
+  final TokenStore _tokenStore;
+  Completer<void>? _restoreCompleter;
+
+  Future<void> restoreSession() async {
+    if (_restoreCompleter != null) {
+      return _restoreCompleter!.future;
+    }
+
+    final completer = Completer<void>();
+    _restoreCompleter = completer;
+    try {
+      final refreshToken = await _tokenStore.readRefreshToken();
+      final accessToken = await _tokenStore.readAccessToken();
+      if (refreshToken == null || accessToken == null) {
+        await _tokenStore.clearTokens();
+        state = const AuthStateUnauthenticated();
+        completer.complete();
+        return;
+      }
+
+      state = const AuthStateAuthenticating();
+      try {
+        final user = await _api.me();
+        state = AuthStateAuthenticated(user);
+      } on Exception {
+        await _tokenStore.clearTokens();
+        state = const AuthStateUnauthenticated();
+      }
+      completer.complete();
+    } finally {
+      _restoreCompleter = null;
+    }
+  }
+
+  Future<User> login({required String email, required String password}) async {
+    state = const AuthStateAuthenticating();
+    try {
+      final response = await _api.login(email: email, password: password);
+      final user = response.user;
+      state = AuthStateAuthenticated(user);
+      return user;
+    } on Exception {
+      await _tokenStore.clearTokens();
+      state = const AuthStateUnauthenticated();
+      rethrow;
+    }
+  }
+
+  Future<void> logout() async {
+    await _tokenStore.clearTokens();
+    state = const AuthStateUnauthenticated();
+  }
+}

--- a/mobile/lib/features/auth/ui/login_page.dart
+++ b/mobile/lib/features/auth/ui/login_page.dart
@@ -1,0 +1,124 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../logic/auth_notifier.dart';
+
+class LoginPage extends ConsumerStatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  ConsumerState<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends ConsumerState<LoginPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  String? _error;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleLogin() async {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+    setState(() => _error = null);
+    try {
+      await ref.read(authNotifierProvider.notifier).login(
+            email: _emailController.text.trim(),
+            password: _passwordController.text,
+          );
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+    } on DioException catch (e) {
+      setState(() {
+        _error = e.response?.data is Map<String, dynamic>
+            ? (e.response?.data['message'] as String?) ?? 'Login failed.'
+            : e.message;
+      });
+    } catch (e) {
+      setState(() {
+        _error = 'Login failed. Please try again.';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authState = ref.watch(authNotifierProvider);
+    final isLoading = authState is AuthStateAuthenticating;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 400),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextFormField(
+                    controller: _emailController,
+                    decoration: const InputDecoration(labelText: 'Email'),
+                    keyboardType: TextInputType.emailAddress,
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Please enter your email.';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _passwordController,
+                    obscureText: true,
+                    decoration: const InputDecoration(labelText: 'Password'),
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Please enter your password.';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  if (_error != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: Text(
+                        _error!,
+                        style: const TextStyle(color: Colors.red),
+                      ),
+                    ),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: isLoading ? null : _handleLogin,
+                      child: isLoading
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Text('Login'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/home/ui/dashboard_page.dart
+++ b/mobile/lib/features/home/ui/dashboard_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: const Center(
+        child: Text('Dashboard content goes here.'),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/home/ui/home_page.dart
+++ b/mobile/lib/features/home/ui/home_page.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../auth/logic/auth_notifier.dart';
+
+class HomePage extends ConsumerWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authNotifierProvider);
+    final isLoading = authState is AuthStateAuthenticating;
+    final isAuthenticated = authState is AuthStateAuthenticated;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('iroha'),
+        actions: [
+          if (isAuthenticated)
+            IconButton(
+              tooltip: 'Logout',
+              onPressed: () async {
+                await ref.read(authNotifierProvider.notifier).logout();
+              },
+              icon: const Icon(Icons.logout),
+            ),
+        ],
+      ),
+      body: Center(
+        child: isLoading
+            ? const CircularProgressIndicator()
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    isAuthenticated
+                        ? 'Welcome back, ${(authState as AuthStateAuthenticated).user.email}!'
+                        : 'Welcome to iroha',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton(
+                    onPressed: () {
+                      if (isAuthenticated) {
+                        Navigator.of(context).pushNamed('/dashboard');
+                      } else {
+                        Navigator.of(context).pushNamed('/login');
+                      }
+                    },
+                    child: Text(isAuthenticated ? 'Dashboard' : 'Login'),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'app.dart';
+
+void main() {
+  runApp(const ProviderScope(child: IrohaApp()));
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,0 +1,24 @@
+name: iroha_mobile
+description: A Flutter client for the iroha platform.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.2.0 <4.0.0'
+  flutter: '>=3.16.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.4.5
+  dio: ^5.3.3
+  flutter_secure_storage: ^9.0.0
+
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold a Flutter mobile client with ProviderScope entry and routing
- add Dio configuration that injects access tokens and refreshes on 401 using secure storage
- implement auth notifier, login UI, and home/dashboard flow that reacts to authentication state

## Testing
- Not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d4b313ea60832f8e42da4be262e892