### PR TITLE
Add catalog browsing capabilities to the mobile app

### DIFF
--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'core/network/dio_provider.dart';
@@ -6,6 +7,11 @@ import 'features/auth/logic/auth_notifier.dart';
 import 'features/auth/ui/login_page.dart';
 import 'features/home/ui/home_page.dart';
 import 'features/home/ui/dashboard_page.dart';
+import 'features/catalog/ui/course_detail_page.dart';
+import 'features/catalog/ui/enroll_placeholder_page.dart';
+import 'features/catalog/ui/season_detail_page.dart';
+import 'features/catalog/ui/seasons_page.dart';
+import 'l10n/app_localizations.dart';
 
 class IrohaApp extends ConsumerWidget {
   const IrohaApp({super.key});
@@ -20,11 +26,48 @@ class IrohaApp extends ConsumerWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
         useMaterial3: true,
       ),
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
       initialRoute: '/',
       routes: {
         '/': (_) => const HomePage(),
         '/login': (_) => const LoginPage(),
         '/dashboard': (_) => const DashboardPage(),
+        '/seasons': (_) => const SeasonsPage(),
+      },
+      onGenerateRoute: (settings) {
+        final name = settings.name;
+        if (name == null) {
+          return null;
+        }
+        final uri = Uri.parse(name);
+        if (uri.pathSegments.length == 2 && uri.pathSegments.first == 'seasons') {
+          final seasonCode = uri.pathSegments[1];
+          return MaterialPageRoute<void>(
+            builder: (_) => SeasonDetailPage(seasonCode: seasonCode),
+            settings: settings,
+          );
+        }
+        if (uri.pathSegments.length == 2 && uri.pathSegments.first == 'courses') {
+          final courseId = uri.pathSegments[1];
+          return MaterialPageRoute<void>(
+            builder: (_) => CourseDetailPage(courseId: courseId),
+            settings: settings,
+          );
+        }
+        if (uri.pathSegments.length == 2 && uri.pathSegments.first == 'enroll') {
+          final courseId = uri.pathSegments[1];
+          return MaterialPageRoute<void>(
+            builder: (_) => EnrollPlaceholderPage(courseId: courseId),
+            settings: settings,
+          );
+        }
+        return null;
       },
     );
   }

--- a/mobile/lib/features/catalog/data/catalog_api.dart
+++ b/mobile/lib/features/catalog/data/catalog_api.dart
@@ -1,0 +1,89 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/dio_provider.dart';
+import '../models/catalog_models.dart';
+
+enum SeasonFilterStatus { enrolling, running }
+
+extension on SeasonFilterStatus {
+  String get value {
+    switch (this) {
+      case SeasonFilterStatus.enrolling:
+        return 'enrolling';
+      case SeasonFilterStatus.running:
+        return 'running';
+    }
+  }
+}
+
+class CatalogApi {
+  const CatalogApi(this._dio);
+
+  final Dio _dio;
+
+  Future<List<SeasonSummary>> fetchSeasons(SeasonFilterStatus status) async {
+    final response = await _dio.get<List<dynamic>>(
+      '/seasons',
+      queryParameters: {'status': status.value},
+      options: Options(extra: const <String, dynamic>{'skipAuth': true}),
+    );
+    final data = response.data ?? [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(SeasonSummary.fromJson)
+        .where((season) => season.code.isNotEmpty)
+        .toList();
+  }
+
+  Future<List<CourseSummary>> fetchCourses({
+    required String seasonCode,
+    int page = 0,
+    int size = 25,
+  }) async {
+    final response = await _dio.get<List<dynamic>>(
+      '/courses',
+      queryParameters: {
+        'season': seasonCode,
+        'published': true,
+        'page': page,
+        'size': size,
+      },
+      options: Options(extra: const <String, dynamic>{'skipAuth': true}),
+    );
+    final data = response.data ?? [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(CourseSummary.fromJson)
+        .where((course) => course.id.isNotEmpty)
+        .toList();
+  }
+
+  Future<CourseDetail> fetchCourseDetail(String courseId) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/courses/$courseId',
+      options: Options(extra: const <String, dynamic>{'skipAuth': true}),
+    );
+    final data = response.data ?? <String, dynamic>{};
+    return CourseDetail.fromJson(data);
+  }
+
+  Future<List<SectionSummary>> fetchSections(String courseId) async {
+    final response = await _dio.get<List<dynamic>>(
+      '/sections',
+      queryParameters: {'courseId': courseId},
+      options: Options(extra: const <String, dynamic>{'skipAuth': true}),
+    );
+    final data = response.data ?? [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(SectionSummary.fromJson)
+        .where((section) => section.id.isNotEmpty)
+        .toList();
+  }
+}
+
+final catalogApiProvider = Provider<CatalogApi>((ref) {
+  final dio = ref.watch(dioProvider);
+  return CatalogApi(dio);
+});

--- a/mobile/lib/features/catalog/logic/catalog_providers.dart
+++ b/mobile/lib/features/catalog/logic/catalog_providers.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/catalog_api.dart';
+import '../models/catalog_models.dart';
+
+final seasonsProvider = FutureProvider<List<SeasonSummary>>((ref) async {
+  final api = ref.watch(catalogApiProvider);
+  final enrolling = await api.fetchSeasons(SeasonFilterStatus.enrolling);
+  final running = await api.fetchSeasons(SeasonFilterStatus.running);
+  final seen = <String>{};
+  final results = <SeasonSummary>[];
+  for (final season in [...enrolling, ...running]) {
+    if (seen.add(season.code)) {
+      results.add(season);
+    }
+  }
+  results.sort(
+    (a, b) => (a.startDate ?? DateTime.fromMillisecondsSinceEpoch(0))
+        .compareTo(b.startDate ?? DateTime.fromMillisecondsSinceEpoch(0)),
+  );
+  return results;
+});
+
+final coursesBySeasonProvider = FutureProvider.family<List<CourseSummary>, String>((ref, code) async {
+  final api = ref.watch(catalogApiProvider);
+  return api.fetchCourses(seasonCode: code);
+});
+
+final courseDetailProvider = FutureProvider.family<CourseDetail, String>((ref, id) async {
+  final api = ref.watch(catalogApiProvider);
+  return api.fetchCourseDetail(id);
+});
+
+final sectionsByCourseProvider = FutureProvider.family<List<SectionSummary>, String>((ref, id) async {
+  final api = ref.watch(catalogApiProvider);
+  return api.fetchSections(id);
+});

--- a/mobile/lib/features/catalog/models/catalog_models.dart
+++ b/mobile/lib/features/catalog/models/catalog_models.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+
+T? _readValue<T>(Map<String, dynamic> json, String key) {
+  final dynamic camelValue = json[key];
+  if (camelValue is T) {
+    return camelValue;
+  }
+  final snakeKey = key.replaceAllMapped(
+    RegExp('[A-Z]'),
+    (match) => '_${match.group(0)!.toLowerCase()}',
+  );
+  final dynamic snakeValue = json[snakeKey];
+  if (snakeValue is T) {
+    return snakeValue;
+  }
+  return null;
+}
+
+DateTime? _parseDateTime(Map<String, dynamic> json, String key) {
+  final value = _readValue<String>(json, key);
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  return DateTime.tryParse(value);
+}
+
+class SeasonSummary {
+  const SeasonSummary({
+    required this.code,
+    required this.title,
+    this.status,
+    this.startDate,
+    this.endDate,
+  });
+
+  factory SeasonSummary.fromJson(Map<String, dynamic> json) {
+    return SeasonSummary(
+      code: _readValue<String>(json, 'code') ?? '',
+      title: _readValue<String>(json, 'title') ?? '',
+      status: _readValue<String>(json, 'status'),
+      startDate: _parseDateTime(json, 'startDate'),
+      endDate: _parseDateTime(json, 'endDate'),
+    );
+  }
+
+  final String code;
+  final String title;
+  final String? status;
+  final DateTime? startDate;
+  final DateTime? endDate;
+}
+
+class CourseSummary {
+  const CourseSummary({
+    required this.id,
+    required this.code,
+    required this.title,
+    this.level,
+    this.priceCents,
+    this.currency,
+    this.seatsLeft,
+  });
+
+  factory CourseSummary.fromJson(Map<String, dynamic> json) {
+    return CourseSummary(
+      id: '${_readValue<dynamic>(json, 'id') ?? ''}',
+      code: _readValue<String>(json, 'code') ?? '',
+      title: _readValue<String>(json, 'title') ?? '',
+      level: _readValue<String>(json, 'level'),
+      priceCents: _readValue<num>(json, 'priceCents')?.toInt(),
+      currency: _readValue<String>(json, 'currency'),
+      seatsLeft: _readValue<num>(json, 'seatsLeft')?.toInt(),
+    );
+  }
+
+  final String id;
+  final String code;
+  final String title;
+  final String? level;
+  final int? priceCents;
+  final String? currency;
+  final int? seatsLeft;
+}
+
+class CourseDetail extends CourseSummary {
+  const CourseDetail({
+    required super.id,
+    required super.code,
+    required super.title,
+    super.level,
+    super.priceCents,
+    super.currency,
+    super.seatsLeft,
+    this.description,
+    this.language,
+    this.modality,
+  });
+
+  factory CourseDetail.fromJson(Map<String, dynamic> json) {
+    return CourseDetail(
+      id: '${_readValue<dynamic>(json, 'id') ?? ''}',
+      code: _readValue<String>(json, 'code') ?? '',
+      title: _readValue<String>(json, 'title') ?? '',
+      level: _readValue<String>(json, 'level'),
+      priceCents: _readValue<num>(json, 'priceCents')?.toInt(),
+      currency: _readValue<String>(json, 'currency'),
+      seatsLeft: _readValue<num>(json, 'seatsLeft')?.toInt(),
+      description: _readValue<String>(json, 'description'),
+      language: _readValue<String>(json, 'language'),
+      modality: _readValue<String>(json, 'modality'),
+    );
+  }
+
+  final String? description;
+  final String? language;
+  final String? modality;
+}
+
+class SectionSummary {
+  const SectionSummary({
+    required this.id,
+    this.title,
+    this.weekday,
+    this.startTime,
+    this.endTime,
+    this.instructorName,
+  });
+
+  factory SectionSummary.fromJson(Map<String, dynamic> json) {
+    final instructor = _readValue<Map<String, dynamic>>(json, 'instructor');
+    String? instructorName;
+    if (instructor != null) {
+      final firstName =
+          _readValue<String>(instructor, 'firstName') ?? _readValue<String>(instructor, 'first_name');
+      final lastName =
+          _readValue<String>(instructor, 'lastName') ?? _readValue<String>(instructor, 'last_name');
+      final parts = <String>[
+        if (firstName != null && firstName.isNotEmpty) firstName,
+        if (lastName != null && lastName.isNotEmpty) lastName,
+      ];
+      instructorName = parts.join(' ');
+      if (instructorName.isEmpty) {
+        instructorName = _readValue<String>(instructor, 'email');
+      }
+    }
+
+    return SectionSummary(
+      id: '${_readValue<dynamic>(json, 'id') ?? ''}',
+      title: _readValue<String>(json, 'title'),
+      weekday: _readValue<num>(json, 'weekday')?.toInt(),
+      startTime: _readValue<String>(json, 'startTime') ?? _readValue<String>(json, 'start_time'),
+      endTime: _readValue<String>(json, 'endTime') ?? _readValue<String>(json, 'end_time'),
+      instructorName: instructorName,
+    );
+  }
+
+  final String id;
+  final String? title;
+  final int? weekday;
+  final String? startTime;
+  final String? endTime;
+  final String? instructorName;
+
+  TimeOfDay? get startTimeOfDay => _parseTimeOfDay(startTime);
+  TimeOfDay? get endTimeOfDay => _parseTimeOfDay(endTime);
+}
+
+TimeOfDay? _parseTimeOfDay(String? value) {
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  final parts = value.split(':');
+  if (parts.length < 2) {
+    return null;
+  }
+  final hour = int.tryParse(parts[0]);
+  final minute = int.tryParse(parts[1]);
+  if (hour == null || minute == null) {
+    return null;
+  }
+  return TimeOfDay(hour: hour, minute: minute);
+}

--- a/mobile/lib/features/catalog/ui/course_detail_page.dart
+++ b/mobile/lib/features/catalog/ui/course_detail_page.dart
@@ -1,0 +1,305 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../logic/catalog_providers.dart';
+import '../models/catalog_models.dart';
+
+class CourseDetailPage extends ConsumerWidget {
+  const CourseDetailPage({required this.courseId, super.key});
+
+  final String courseId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final courseValue = ref.watch(courseDetailProvider(courseId));
+    final sectionsValue = ref.watch(sectionsByCourseProvider(courseId));
+    final l10n = context.l10n;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.courseDetailsTitle),
+      ),
+      body: SafeArea(
+        child: courseValue.when(
+          data: (course) => RefreshIndicator(
+            onRefresh: () async {
+              ref.invalidate(courseDetailProvider(courseId));
+              ref.invalidate(sectionsByCourseProvider(courseId));
+              await Future.wait([
+                ref.read(courseDetailProvider(courseId).future),
+                ref.read(sectionsByCourseProvider(courseId).future),
+              ]);
+            },
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                _CourseOverviewContent(course: course),
+                const SizedBox(height: 24),
+                _SectionsContent(
+                  courseId: courseId,
+                  sectionsValue: sectionsValue,
+                ),
+                const SizedBox(height: 24),
+                Align(
+                  alignment: Alignment.center,
+                  child: FilledButton(
+                    onPressed: () {
+                      Navigator.of(context).pushNamed('/enroll/$courseId');
+                    },
+                    child: Text(l10n.enroll),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          error: (error, _) => _ErrorState(
+            message: l10n.errorMessage,
+            onRetry: () {
+              ref.invalidate(courseDetailProvider(courseId));
+            },
+          ),
+          loading: () => const Center(child: CircularProgressIndicator()),
+        ),
+      ),
+    );
+  }
+}
+
+class _CourseOverviewContent extends StatelessWidget {
+  const _CourseOverviewContent({required this.course});
+
+  final CourseDetail course;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final locale = Localizations.localeOf(context).toLanguageTag();
+    final price = course.priceCents != null
+        ? (course.currency != null && course.currency!.isNotEmpty
+            ? NumberFormat.simpleCurrency(name: course.currency, locale: locale)
+            : NumberFormat.simpleCurrency(locale: locale))
+            .format(course.priceCents! / 100)
+        : null;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(course.title, style: theme.textTheme.headlineSmall),
+            const SizedBox(height: 8),
+            Text(course.code, style: theme.textTheme.bodyMedium),
+            if (course.level != null) ...[
+              const SizedBox(height: 8),
+              Text(course.level!, style: theme.textTheme.bodyMedium),
+            ],
+            if (price != null) ...[
+              const SizedBox(height: 8),
+              Text(price, style: theme.textTheme.titleMedium),
+            ],
+            if (course.description != null && course.description!.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              Text(course.description!, style: theme.textTheme.bodyMedium),
+            ],
+            if (course.language != null || course.modality != null) ...[
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 12,
+                runSpacing: 8,
+                children: [
+                  if (course.language != null)
+                    Chip(
+                      avatar: const Icon(Icons.language, size: 18),
+                      label: Text(course.language!),
+                    ),
+                  if (course.modality != null)
+                    Chip(
+                      avatar: const Icon(Icons.cast_for_education, size: 18),
+                      label: Text(course.modality!),
+                    ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionsContent extends ConsumerWidget {
+  const _SectionsContent({required this.courseId, required this.sectionsValue});
+
+  final String courseId;
+  final AsyncValue<List<SectionSummary>> sectionsValue;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    return sectionsValue.when(
+      data: (sections) {
+        if (sections.isEmpty) {
+          return _EmptyState(message: l10n.noSectionsMessage);
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(l10n.sectionsTitle, style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 12),
+            for (final section in sections)
+              _SectionTile(
+                key: ValueKey(section.id),
+                section: section,
+              ),
+          ],
+        );
+      },
+      error: (error, _) => _ErrorState(
+        message: l10n.errorMessage,
+        onRetry: () {
+          ref.invalidate(sectionsByCourseProvider(courseId));
+        },
+      ),
+      loading: () => const Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: Center(child: CircularProgressIndicator()),
+      ),
+    );
+  }
+}
+
+class _SectionTile extends StatelessWidget {
+  const _SectionTile({super.key, required this.section});
+
+  final SectionSummary section;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final subtitle = _buildSubtitle(context);
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        leading: _WeekdayAvatar(weekday: section.weekday),
+        title: Text(section.title ?? context.l10n.sectionFallbackTitle(section.id)),
+        subtitle: subtitle != null ? Text(subtitle) : null,
+        trailing: section.instructorName != null
+            ? Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    section.instructorName!,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  Text(
+                    context.l10n.instructorLabel,
+                    style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  ),
+                ],
+              )
+            : null,
+      ),
+    );
+  }
+
+  String? _buildSubtitle(BuildContext context) {
+    final start = section.startTimeOfDay;
+    final end = section.endTimeOfDay;
+    if (start == null && end == null) {
+      return null;
+    }
+    final materialLocalizations = MaterialLocalizations.of(context);
+    if (start != null && end != null) {
+      return '${materialLocalizations.formatTimeOfDay(start)} - ${materialLocalizations.formatTimeOfDay(end)}';
+    }
+    if (start != null) {
+      return materialLocalizations.formatTimeOfDay(start);
+    }
+    return materialLocalizations.formatTimeOfDay(end!);
+  }
+}
+
+class _WeekdayAvatar extends StatelessWidget {
+  const _WeekdayAvatar({this.weekday});
+
+  final int? weekday;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final label = _weekdayLabel(context);
+    return CircleAvatar(
+      backgroundColor: theme.colorScheme.primaryContainer,
+      child: Text(
+        label,
+        style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onPrimaryContainer),
+      ),
+    );
+  }
+
+  String _weekdayLabel(BuildContext context) {
+    if (weekday == null) {
+      return '--';
+    }
+    final normalized = ((weekday! % 7) + 7) % 7;
+    final baseDate = DateTime(2024, 1, 1 + normalized);
+    final locale = Localizations.localeOf(context).toLanguageTag();
+    return DateFormat.E(locale).format(baseDate).substring(0, 3).toUpperCase();
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Center(
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              message,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton(
+              onPressed: onRetry,
+              child: Text(l10n.retry),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/catalog/ui/enroll_placeholder_page.dart
+++ b/mobile/lib/features/catalog/ui/enroll_placeholder_page.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+
+class EnrollPlaceholderPage extends StatelessWidget {
+  const EnrollPlaceholderPage({required this.courseId, super.key});
+
+  final String courseId;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.enroll),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            l10n.enrollmentPlaceholder(courseId),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/catalog/ui/season_detail_page.dart
+++ b/mobile/lib/features/catalog/ui/season_detail_page.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../logic/catalog_providers.dart';
+import '../models/catalog_models.dart';
+
+class SeasonDetailPage extends ConsumerWidget {
+  const SeasonDetailPage({required this.seasonCode, super.key});
+
+  final String seasonCode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final coursesValue = ref.watch(coursesBySeasonProvider(seasonCode));
+    final l10n = context.l10n;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${l10n.coursesTitle} • $seasonCode'),
+      ),
+      body: coursesValue.when(
+        data: (courses) {
+          if (courses.isEmpty) {
+            return _EmptyState(message: l10n.noCoursesMessage);
+          }
+          return RefreshIndicator(
+            onRefresh: () async {
+              ref.invalidate(coursesBySeasonProvider(seasonCode));
+              await ref.read(coursesBySeasonProvider(seasonCode).future);
+            },
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemBuilder: (context, index) {
+                final course = courses[index];
+                return _CourseCard(course: course);
+              },
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemCount: courses.length,
+            ),
+          );
+        },
+        error: (error, _) => _ErrorState(
+          message: l10n.errorMessage,
+          onRetry: () {
+            ref.invalidate(coursesBySeasonProvider(seasonCode));
+          },
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+      ),
+    );
+  }
+}
+
+class _CourseCard extends StatelessWidget {
+  const _CourseCard({required this.course});
+
+  final CourseSummary course;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(course.title, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 4),
+            Text(course.code, style: theme.textTheme.bodySmall),
+            if (course.level != null) ...[
+              const SizedBox(height: 8),
+              Text(course.level!, style: theme.textTheme.bodyMedium),
+            ],
+            if (course.priceCents != null || course.seatsLeft != null) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 16,
+                runSpacing: 8,
+                children: [
+                  if (course.priceCents != null)
+                    _InfoChip(
+                      icon: Icons.payments_outlined,
+                      label: _formatPrice(context, course.priceCents!, course.currency),
+                    ),
+                  if (course.seatsLeft != null)
+                    _InfoChip(
+                      icon: Icons.event_seat_outlined,
+                      label: l10n.seatsLeft(course.seatsLeft!),
+                    ),
+                ],
+              ),
+            ],
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton(
+                onPressed: () {
+                  Navigator.of(context).pushNamed('/courses/${course.id}');
+                },
+                child: Text(l10n.viewCourse),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatPrice(BuildContext context, int priceCents, String? currency) {
+    final locale = Localizations.localeOf(context).toLanguageTag();
+    final formatter = currency != null && currency.isNotEmpty
+        ? NumberFormat.simpleCurrency(name: currency, locale: locale)
+        : NumberFormat.simpleCurrency(locale: locale);
+    return formatter.format(priceCents / 100);
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18, color: theme.colorScheme.primary),
+          const SizedBox(width: 6),
+          Text(label, style: theme.textTheme.bodySmall),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              message,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton(
+              onPressed: onRetry,
+              child: Text(l10n.retry),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/catalog/ui/seasons_page.dart
+++ b/mobile/lib/features/catalog/ui/seasons_page.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../logic/catalog_providers.dart';
+import '../models/catalog_models.dart';
+
+class SeasonsPage extends ConsumerWidget {
+  const SeasonsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final seasonsValue = ref.watch(seasonsProvider);
+    final l10n = context.l10n;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.seasonsTitle),
+      ),
+      body: seasonsValue.when(
+        data: (seasons) {
+          if (seasons.isEmpty) {
+            return _EmptyState(message: l10n.noSeasonsMessage);
+          }
+          return RefreshIndicator(
+            onRefresh: () async {
+              ref.invalidate(seasonsProvider);
+              await ref.read(seasonsProvider.future);
+            },
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemBuilder: (context, index) {
+                final season = seasons[index];
+                return _SeasonCard(season: season);
+              },
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemCount: seasons.length,
+            ),
+          );
+        },
+        error: (error, _) => _ErrorState(
+          message: l10n.errorMessage,
+          onRetry: () {
+            ref.invalidate(seasonsProvider);
+          },
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+      ),
+    );
+  }
+}
+
+class _SeasonCard extends StatelessWidget {
+  const _SeasonCard({required this.season});
+
+  final SeasonSummary season;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final subtitle = _buildSubtitle(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              season.title,
+              style: theme.textTheme.titleLarge,
+            ),
+            if (subtitle != null) ...[
+              const SizedBox(height: 8),
+              Text(subtitle, style: theme.textTheme.bodyMedium),
+            ],
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton(
+                onPressed: () {
+                  Navigator.of(context).pushNamed('/seasons/${season.code}');
+                },
+                child: Text(l10n.browse),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String? _buildSubtitle(BuildContext context) {
+    final start = season.startDate;
+    final end = season.endDate;
+    if (start == null && end == null) {
+      return null;
+    }
+    final locale = Localizations.localeOf(context).toLanguageTag();
+    final formatter = DateFormat.yMMMMd(locale);
+    if (start != null && end != null) {
+      return '${formatter.format(start)} • ${formatter.format(end)}';
+    }
+    if (start != null) {
+      return formatter.format(start);
+    }
+    return formatter.format(end!);
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              message,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton(
+              onPressed: onRetry,
+              child: Text(l10n.retry),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/home/ui/home_page.dart
+++ b/mobile/lib/features/home/ui/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../auth/logic/auth_notifier.dart';
+import '../../../l10n/app_localizations.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({super.key});
@@ -49,6 +50,13 @@ class HomePage extends ConsumerWidget {
                       }
                     },
                     child: Text(isAuthenticated ? 'Dashboard' : 'Login'),
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(
+                    onPressed: () {
+                      Navigator.of(context).pushNamed('/seasons');
+                    },
+                    child: Text(context.l10n.viewSeasons),
                   ),
                 ],
               ),

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/widgets.dart';
+
+class AppLocalizations {
+  AppLocalizations(this.locale);
+
+  final Locale locale;
+
+  static const supportedLocales = [Locale('en')];
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  static AppLocalizations of(BuildContext context) {
+    final localizations = Localizations.of<AppLocalizations>(context, AppLocalizations);
+    assert(localizations != null, 'No AppLocalizations found in context');
+    return localizations!;
+  }
+
+  String get browse => 'Browse';
+  String get loading => 'Loading…';
+  String get retry => 'Retry';
+  String get enroll => 'Enroll';
+  String get viewSeasons => 'Browse catalog';
+  String get viewCourse => 'View course';
+  String get noSeasonsMessage => 'No seasons are currently available.';
+  String get noCoursesMessage => 'No courses are available for this season yet.';
+  String get noSectionsMessage => 'Sections will be announced soon.';
+  String get errorMessage => 'Something went wrong. Please try again later.';
+  String get seasonsTitle => 'Seasons';
+  String get coursesTitle => 'Courses';
+  String get sectionsTitle => 'Sections';
+  String get courseDetailsTitle => 'Course details';
+  String get instructorLabel => 'Instructor';
+  String seatsLeft(int count) => '$count seats left';
+  String sectionFallbackTitle(String id) => 'Section $id';
+  String enrollmentPlaceholder(String courseId) => 'Enrollment flow for $courseId coming soon.';
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => AppLocalizations.supportedLocales.contains(Locale(locale.languageCode));
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) => false;
+}
+
+extension AppLocalizationsX on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this);
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -13,6 +13,9 @@ dependencies:
   flutter_riverpod: ^2.4.5
   dio: ^5.3.3
   flutter_secure_storage: ^9.0.0
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.18.1
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- implement a catalog API client and Riverpod providers for seasons, courses, course details, and sections
- add localized strings plus an enrollment placeholder route, and surface the catalog entry point from the home screen
- build new seasons, season detail, and course detail pages with loading, empty, and error states

## Testing
- unable to run `flutter pub get` (Flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d4b5366eb0832fba8e5b7ac8596c7b