### PR TITLE
Add Firebase notifications skeleton for mobile app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,28 @@ export NEXT_PUBLIC_RETURN_URL="http://localhost:3000/payment/return"
 ```
 
 This URL is shared with the payment provider to handle the browser return flow after checkout.
+
+## Mobile Push Notifications
+
+The Flutter client includes Firebase Cloud Messaging (FCM) hooks and a local notification fallback. To finish the integration:
+
+1. **Add the Firebase configuration files locally**: copy your real `google-services.json` into `mobile/android/app/` and `GoogleService-Info.plist` into `mobile/ios/Runner/`. The repository only ships placeholders, so keep the production files out of source control.
+2. **Android manifest configuration**:
+   - Ensure the app declares the following permissions inside `android/app/src/main/AndroidManifest.xml`:
+     ```xml
+     <uses-permission android:name="android.permission.INTERNET" />
+     <uses-permission android:name="android.permission.WAKE_LOCK" />
+     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+     ```
+   - Add the Firebase messaging service to the `<application>` tag if it is not already present:
+     ```xml
+     <service
+         android:name="com.google.firebase.messaging.FirebaseMessagingService"
+         android:exported="false">
+         <intent-filter>
+             <action android:name="com.google.firebase.MESSAGING_EVENT" />
+         </intent-filter>
+     </service>
+     ```
+3. **iOS capabilities**: enable *Push Notifications* and the *Background Modes → Remote notifications* capability for the Runner target in Xcode. This ensures that `FirebaseMessaging` can receive messages while the app is in the background.
+4. **Runtime behaviour**: the app requests notification permissions on iOS, registers background and foreground handlers, and exposes the FCM token through a Riverpod provider. After a learner’s enrolment becomes `active`, call `NotificationService.subscribeToCourseTopic('courses/<courseId>')` to opt them into course-specific updates.

--- a/mobile/android/app/google-services.json
+++ b/mobile/android/app/google-services.json
@@ -1,0 +1,22 @@
+{
+  "project_info": {
+    "project_id": "replace-with-your-project-id",
+    "project_number": "000000000000"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:placeholder",
+        "android_client_info": {
+          "package_name": "com.example.replace"
+        }
+      },
+      "api_key": [
+        {
+          "current_key": "replace-with-your-api-key"
+        }
+      ]
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/mobile/ios/Runner/GoogleService-Info.plist
+++ b/mobile/ios/Runner/GoogleService-Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CLIENT_ID</key>
+<string>replace-with-your-client-id</string>
+<key>REVERSED_CLIENT_ID</key>
+<string>replace.with.your.reversed.id</string>
+<key>API_KEY</key>
+<string>replace-with-your-ios-api-key</string>
+<key>GCM_SENDER_ID</key>
+<string>000000000000</string>
+<key>GOOGLE_APP_ID</key>
+<string>1:000000000000:ios:placeholder</string>
+<key>BUNDLE_ID</key>
+<string>com.example.replace</string>
+<key>PROJECT_ID</key>
+<string>replace-with-your-project-id</string>
+</dict>
+</plist>

--- a/mobile/lib/core/notifications/notification_service.dart
+++ b/mobile/lib/core/notifications/notification_service.dart
@@ -1,0 +1,126 @@
+import 'dart:convert';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+const AndroidNotificationChannel _defaultAndroidChannel = AndroidNotificationChannel(
+  'iroha_default',
+  'Iroha notifications',
+  description: 'General course updates and reminders.',
+  importance: Importance.high,
+);
+
+final FlutterLocalNotificationsPlugin _localNotificationsPlugin = FlutterLocalNotificationsPlugin();
+
+@pragma('vm:entry-point')
+Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp();
+  final plugin = FlutterLocalNotificationsPlugin();
+  await NotificationService._initializeLocalNotifications(plugin);
+  await NotificationService.showRemoteMessageNotification(message, plugin: plugin);
+}
+
+final firebaseMessagingProvider = Provider<FirebaseMessaging>((ref) {
+  return FirebaseMessaging.instance;
+});
+
+final fcmTokenProvider = StreamProvider<String?>((ref) async* {
+  final messaging = ref.watch(firebaseMessagingProvider);
+  final initialToken = await messaging.getToken();
+  yield initialToken;
+  yield* messaging.onTokenRefresh;
+});
+
+class NotificationService {
+  NotificationService._();
+
+  static Future<void> initialize() async {
+    FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
+    await _initializeFirebaseMessaging();
+    await _initializeLocalNotifications(_localNotificationsPlugin);
+
+    FirebaseMessaging.onMessage.listen((message) async {
+      await showRemoteMessageNotification(message);
+    });
+  }
+
+  static Future<void> _initializeFirebaseMessaging() async {
+    final messaging = FirebaseMessaging.instance;
+
+    await messaging.requestPermission(
+      alert: true,
+      badge: true,
+      sound: true,
+      announcement: false,
+      carPlay: false,
+      criticalAlert: false,
+      provisional: false,
+    );
+
+    await messaging.setForegroundNotificationPresentationOptions(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
+  }
+
+  static Future<void> _initializeLocalNotifications(FlutterLocalNotificationsPlugin plugin) async {
+    const initializationSettings = InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+      iOS: DarwinInitializationSettings(),
+    );
+
+    await plugin.initialize(initializationSettings);
+
+    final androidPlugin = plugin.resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+    await androidPlugin?.createNotificationChannel(_defaultAndroidChannel);
+  }
+
+  static Future<void> showRemoteMessageNotification(
+    RemoteMessage message, {
+    FlutterLocalNotificationsPlugin? plugin,
+  }) async {
+    final usedPlugin = plugin ?? _localNotificationsPlugin;
+    final notification = message.notification;
+
+    final title = notification?.title ?? message.data['title'] as String?;
+    final body = notification?.body ?? message.data['body'] as String?;
+
+    if (title == null && body == null) {
+      return;
+    }
+
+    final androidDetails = AndroidNotificationDetails(
+      _defaultAndroidChannel.id,
+      _defaultAndroidChannel.name,
+      channelDescription: _defaultAndroidChannel.description,
+      importance: Importance.high,
+      priority: Priority.high,
+    );
+
+    const iosDetails = DarwinNotificationDetails();
+
+    final payload = message.data.isEmpty ? null : jsonEncode(message.data);
+
+    await usedPlugin.show(
+      notification?.hashCode ?? message.hashCode,
+      title,
+      body,
+      NotificationDetails(
+        android: androidDetails,
+        iOS: iosDetails,
+      ),
+      payload: payload,
+    );
+  }
+
+  static Future<void> subscribeToCourseTopic(String courseId) async {
+    if (courseId.isEmpty) {
+      return;
+    }
+
+    await FirebaseMessaging.instance.subscribeToTopic('courses/$courseId');
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,8 +1,14 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
+import 'core/notifications/notification_service.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  await NotificationService.initialize();
+
   runApp(const ProviderScope(child: IrohaApp()));
 }

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -13,6 +13,9 @@ dependencies:
   flutter_riverpod: ^2.4.5
   dio: ^5.3.3
   flutter_secure_storage: ^9.0.0
+  firebase_core: ^2.24.2
+  firebase_messaging: ^14.7.10
+  flutter_local_notifications: ^17.1.2
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- initialize Firebase before running the Riverpod scope
- add a notification service that wires FCM handlers, exposes the FCM token, and subscribes to course topics
- document mobile push setup and add placeholder Firebase configuration files

## Testing
- flutter pub get *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b5558870832fbba1313f53b47cea