### PR TITLE
Add multilingual catalog localizations

### DIFF
--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -5,7 +5,7 @@ class AppLocalizations {
 
   final Locale locale;
 
-  static const supportedLocales = [Locale('en')];
+  static const supportedLocales = [Locale('en'), Locale('ar'), Locale('ja')];
 
   static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
 
@@ -15,24 +15,102 @@ class AppLocalizations {
     return localizations!;
   }
 
-  String get browse => 'Browse';
-  String get loading => 'Loading…';
-  String get retry => 'Retry';
-  String get enroll => 'Enroll';
-  String get viewSeasons => 'Browse catalog';
-  String get viewCourse => 'View course';
-  String get noSeasonsMessage => 'No seasons are currently available.';
-  String get noCoursesMessage => 'No courses are available for this season yet.';
-  String get noSectionsMessage => 'Sections will be announced soon.';
-  String get errorMessage => 'Something went wrong. Please try again later.';
-  String get seasonsTitle => 'Seasons';
-  String get coursesTitle => 'Courses';
-  String get sectionsTitle => 'Sections';
-  String get courseDetailsTitle => 'Course details';
-  String get instructorLabel => 'Instructor';
-  String seatsLeft(int count) => '$count seats left';
-  String sectionFallbackTitle(String id) => 'Section $id';
-  String enrollmentPlaceholder(String courseId) => 'Enrollment flow for $courseId coming soon.';
+  static const Map<String, Map<String, String>> _localizedValues = {
+    'en': {
+      'browse': 'Browse',
+      'loading': 'Loading…',
+      'retry': 'Retry',
+      'enroll': 'Enroll',
+      'viewSeasons': 'Browse catalog',
+      'viewCourse': 'View course',
+      'noSeasonsMessage': 'No seasons are currently available.',
+      'noCoursesMessage': 'No courses are available for this season yet.',
+      'noSectionsMessage': 'Sections will be announced soon.',
+      'errorMessage': 'Something went wrong. Please try again later.',
+      'seasonsTitle': 'Seasons',
+      'coursesTitle': 'Courses',
+      'sectionsTitle': 'Sections',
+      'courseDetailsTitle': 'Course details',
+      'instructorLabel': 'Instructor',
+      'seatsLeft': '{count} seats left',
+      'sectionFallbackTitle': 'Section {id}',
+      'enrollmentPlaceholder': 'Enrollment flow for {courseId} coming soon.',
+    },
+    'ar': {
+      'browse': 'تصفح',
+      'loading': 'جارٍ التحميل…',
+      'retry': 'إعادة المحاولة',
+      'enroll': 'التسجيل',
+      'viewSeasons': 'تصفح الكتالوج',
+      'viewCourse': 'عرض الدورة',
+      'noSeasonsMessage': 'لا توجد مواسم متاحة حالياً.',
+      'noCoursesMessage': 'لا توجد دورات لهذا الموسم بعد.',
+      'noSectionsMessage': 'سيتم الإعلان عن المجموعات قريباً.',
+      'errorMessage': 'حدث خطأ ما. يرجى المحاولة لاحقاً.',
+      'seasonsTitle': 'المواسم',
+      'coursesTitle': 'الدورات',
+      'sectionsTitle': 'المجموعات',
+      'courseDetailsTitle': 'تفاصيل الدورة',
+      'instructorLabel': 'المدرب',
+      'seatsLeft': 'المقاعد المتبقية: {count}',
+      'sectionFallbackTitle': 'المجموعة {id}',
+      'enrollmentPlaceholder': 'عملية التسجيل للدورة {courseId} قيد الإعداد.',
+    },
+    'ja': {
+      'browse': '閲覧',
+      'loading': '読み込み中…',
+      'retry': '再試行',
+      'enroll': '申し込む',
+      'viewSeasons': 'カタログを見る',
+      'viewCourse': '講座を見る',
+      'noSeasonsMessage': '現在利用可能なシーズンはありません。',
+      'noCoursesMessage': 'このシーズンの講座はまだありません。',
+      'noSectionsMessage': 'クラス情報は近日公開予定です。',
+      'errorMessage': '問題が発生しました。しばらくしてからもう一度お試しください。',
+      'seasonsTitle': 'シーズン',
+      'coursesTitle': '講座',
+      'sectionsTitle': 'クラス',
+      'courseDetailsTitle': '講座の詳細',
+      'instructorLabel': '講師',
+      'seatsLeft': '残り{count}席',
+      'sectionFallbackTitle': 'クラス{id}',
+      'enrollmentPlaceholder': '{courseId} の申込フローは準備中です。',
+    },
+  };
+
+  String _translate(String key) {
+    final languageCode = locale.languageCode;
+    final values = _localizedValues[languageCode] ?? _localizedValues['en']!;
+    return values[key] ?? _localizedValues['en']![key] ?? key;
+  }
+
+  String _format(String key, Map<String, String> params) {
+    var value = _translate(key);
+    params.forEach((placeholder, replacement) {
+      value = value.replaceAll('{$placeholder}', replacement);
+    });
+    return value;
+  }
+
+  String get browse => _translate('browse');
+  String get loading => _translate('loading');
+  String get retry => _translate('retry');
+  String get enroll => _translate('enroll');
+  String get viewSeasons => _translate('viewSeasons');
+  String get viewCourse => _translate('viewCourse');
+  String get noSeasonsMessage => _translate('noSeasonsMessage');
+  String get noCoursesMessage => _translate('noCoursesMessage');
+  String get noSectionsMessage => _translate('noSectionsMessage');
+  String get errorMessage => _translate('errorMessage');
+  String get seasonsTitle => _translate('seasonsTitle');
+  String get coursesTitle => _translate('coursesTitle');
+  String get sectionsTitle => _translate('sectionsTitle');
+  String get courseDetailsTitle => _translate('courseDetailsTitle');
+  String get instructorLabel => _translate('instructorLabel');
+  String seatsLeft(int count) => _format('seatsLeft', {'count': '$count'});
+  String sectionFallbackTitle(String id) => _format('sectionFallbackTitle', {'id': id});
+  String enrollmentPlaceholder(String courseId) =>
+      _format('enrollmentPlaceholder', {'courseId': courseId});
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {


### PR DESCRIPTION
## Summary
- expand in-app localizations to include Arabic and Japanese strings for the catalog experience
- centralize catalog copy lookups through keyed translations with placeholder formatting support

## Testing
- flutter pub get *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c25e7840832faf48d3b4ac3e85d7