### PR TITLE
Add Flutter mobile build workflow

### DIFF
--- a/.github/workflows/flutter-mobile.yml
+++ b/.github/workflows/flutter-mobile.yml
@@ -1,0 +1,17 @@
+name: Build Flutter (mobile)
+on:
+  push: { branches: [main, staging] }
+  workflow_dispatch:
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with: { channel: 'stable' }
+      - run: flutter pub get
+        working-directory: mobile
+      - run: flutter build apk --release --dart-define=API_BASE_URL=${{ secrets.MOBILE_API_BASE_URL }} --dart-define=RETURN_URL=iroha://payment/return
+        working-directory: mobile
+      - uses: actions/upload-artifact@v4
+        with: { name: iroha-apk, path: mobile/build/app/outputs/flutter-apk/*.apk }


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build the Flutter mobile application for pushes to main and staging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c8d68d28832f962da2d73d81d68e