### PR TITLE
Add Firebase messaging scaffolding

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -10,3 +10,7 @@ build/
 # IntelliJ
 .idea/
 *.iml
+
+# Firebase configuration files (do not commit secrets)
+android/app/google-services.json
+ios/Runner/GoogleService-Info.plist

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,28 @@
+# iroha mobile
+
+## Notifications
+
+Firebase Cloud Messaging (FCM) and local notifications are configured in the
+project but require you to supply your own Firebase configuration files:
+
+1. Create or access the Firebase project for iroha.
+2. Download `google-services.json` from the Firebase console and place it in
+   `mobile/android/app/google-services.json`.
+3. Download `GoogleService-Info.plist` and place it in
+   `mobile/ios/Runner/GoogleService-Info.plist`.
+4. For iOS, enable *Push Notifications* and *Background Modes → Remote
+   notifications* in Xcode for the Runner target, and call `FirebaseApp.configure()`
+   in `AppDelegate`.
+
+The files above are ignored by git; do not commit them to the repository.
+
+### Testing push notifications
+
+1. Run the application on a physical device or emulator.
+2. Open the notifications debug page (AppBar → Notifications debug) in a debug
+   build and copy the displayed FCM token.
+3. Use the Firebase console (Cloud Messaging) or your own backend to send a
+   test push message to the copied token.
+4. Foreground messages display a local notification. Background messages are
+   handled by the background message handler defined in
+   `lib/core/notifications/notifications.dart`.

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    id 'com.google.gms.google-services'
+}
+
+android {
+    compileSdkVersion 34
+
+    defaultConfig {
+        minSdkVersion 21
+    }
+}

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.iroha">
+
+    <application>
+        <service
+            android:name="com.google.firebase.messaging.FirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="iroha_default" />
+    </application>
+
+</manifest>

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -1,0 +1,21 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.google.gms:google-services:4.4.2'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+tasks.register("clean", Delete) {
+    delete rootProject.buildDir
+}

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -6,6 +6,7 @@ import 'core/network/dio_provider.dart';
 import 'features/auth/logic/auth_notifier.dart';
 import 'features/auth/ui/login_page.dart';
 import 'features/home/ui/home_page.dart';
+import 'core/notifications/notifications.dart';
 import 'features/home/ui/dashboard_page.dart';
 import 'features/catalog/ui/course_detail_page.dart';
 import 'features/enroll/ui/enroll_page.dart';
@@ -13,6 +14,7 @@ import 'features/catalog/ui/season_detail_page.dart';
 import 'features/catalog/ui/seasons_page.dart';
 import 'features/payments/ui/checkout_page.dart';
 import 'features/payments/ui/payment_return_page.dart';
+import 'features/debug/notifications_debug_page.dart';
 import 'l10n/app_localizations.dart';
 
 class IrohaApp extends ConsumerWidget {
@@ -24,6 +26,7 @@ class IrohaApp extends ConsumerWidget {
 
     return MaterialApp(
       title: 'iroha',
+      navigatorKey: navigatorKey,
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
         useMaterial3: true,
@@ -41,6 +44,7 @@ class IrohaApp extends ConsumerWidget {
         '/login': (_) => const LoginPage(),
         '/dashboard': (_) => const DashboardPage(),
         '/seasons': (_) => const SeasonsPage(),
+        '/debug/notifications': (_) => const NotificationsDebugPage(),
       },
       onGenerateRoute: (settings) {
         final name = settings.name;

--- a/mobile/lib/core/notifications/local_notifications.dart
+++ b/mobile/lib/core/notifications/local_notifications.dart
@@ -1,0 +1,75 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+const AndroidNotificationChannel irohaDefaultChannel = AndroidNotificationChannel(
+  'iroha_default',
+  'Iroha Notifications',
+  description: 'Default notification channel for iroha.',
+  importance: Importance.high,
+);
+
+final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+    FlutterLocalNotificationsPlugin();
+
+typedef LocalNotificationTapCallback = Future<void> Function(String payload);
+
+LocalNotificationTapCallback? _notificationTapCallback;
+
+void setLocalNotificationTapCallback(LocalNotificationTapCallback? callback) {
+  _notificationTapCallback = callback;
+}
+
+Future<void> initializeNotificationPlugin() async {
+  const initializationSettings = InitializationSettings(
+    android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+    iOS: DarwinInitializationSettings(),
+  );
+
+  await flutterLocalNotificationsPlugin.initialize(
+    initializationSettings,
+    onDidReceiveNotificationResponse: (response) async {
+      final payload = response.payload;
+      if (payload == null || payload.isEmpty) {
+        return;
+      }
+      final handler = _notificationTapCallback;
+      if (handler != null) {
+        await handler(payload);
+      }
+    },
+  );
+
+  final androidImplementation = flutterLocalNotificationsPlugin
+      .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>();
+  await androidImplementation?.createNotificationChannel(irohaDefaultChannel);
+}
+
+Future<void> showLocalNotification(RemoteMessage message) async {
+  final notification = message.notification;
+  final payload = message.data['deep_link'] ?? message.data['payload'];
+
+  final androidDetails = AndroidNotificationDetails(
+    irohaDefaultChannel.id,
+    irohaDefaultChannel.name,
+    channelDescription: irohaDefaultChannel.description,
+    importance: irohaDefaultChannel.importance,
+    priority: Priority.high,
+    icon: notification?.android?.smallIcon,
+  );
+
+  const iosDetails = DarwinNotificationDetails();
+
+  final notificationDetails = NotificationDetails(
+    android: androidDetails,
+    iOS: iosDetails,
+  );
+
+  await flutterLocalNotificationsPlugin.show(
+    notification?.hashCode ?? message.hashCode,
+    notification?.title ?? message.data['title'],
+    notification?.body ?? message.data['body'],
+    notificationDetails,
+    payload: payload,
+  );
+}

--- a/mobile/lib/core/notifications/notifications.dart
+++ b/mobile/lib/core/notifications/notifications.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'local_notifications.dart';
+
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+final Provider<FirebaseMessaging> firebaseMessagingProvider =
+    Provider<FirebaseMessaging>((ref) {
+  return FirebaseMessaging.instance;
+});
+
+final StreamProvider<String?> fcmTokenProvider =
+    StreamProvider<String?>((ref) async* {
+  final messaging = ref.watch(firebaseMessagingProvider);
+  final initialToken = await messaging.getToken();
+  yield initialToken;
+  yield* messaging.onTokenRefresh;
+});
+
+Future<void> initFirebase() async {
+  await Firebase.initializeApp();
+}
+
+Future<NotificationSettings> requestPermissions() async {
+  final messaging = FirebaseMessaging.instance;
+  final settings = await messaging.requestPermission();
+  await messaging.setForegroundNotificationPresentationOptions(
+    alert: true,
+    badge: true,
+    sound: true,
+  );
+  return settings;
+}
+
+Future<String?> getFcmToken() {
+  return FirebaseMessaging.instance.getToken();
+}
+
+Future<void> configureHandlers() async {
+  FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
+
+  setLocalNotificationTapCallback((payload) async {
+    await _handleDeepLink(payload);
+  });
+
+  FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
+    await showLocalNotification(message);
+  });
+
+  FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) async {
+    final deepLink = message.data['deep_link'] as String?;
+    if (deepLink != null && deepLink.isNotEmpty) {
+      await _handleDeepLink(deepLink);
+    }
+  });
+
+  final initialMessage = await FirebaseMessaging.instance.getInitialMessage();
+  if (initialMessage != null) {
+    final deepLink = initialMessage.data['deep_link'] as String?;
+    if (deepLink != null && deepLink.isNotEmpty) {
+      unawaited(_handleDeepLink(deepLink));
+    }
+  }
+}
+
+Future<void> subscribeToCourseTopic(String courseId) {
+  return FirebaseMessaging.instance.subscribeToTopic('course_$courseId');
+}
+
+Future<void> unsubscribeFromCourseTopic(String courseId) {
+  return FirebaseMessaging.instance.unsubscribeFromTopic('course_$courseId');
+}
+
+@pragma('vm:entry-point')
+Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp();
+  await initializeNotificationPlugin();
+  await showLocalNotification(message);
+}
+
+Future<void> _handleDeepLink(String deepLink) async {
+  final uri = Uri.tryParse(deepLink);
+  if (uri == null) {
+    return;
+  }
+
+  if (uri.hasScheme && (uri.scheme == 'http' || uri.scheme == 'https')) {
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+    return;
+  }
+
+  final navigator = navigatorKey.currentState;
+  if (navigator == null) {
+    return;
+  }
+
+  if (uri.hasScheme) {
+    await navigator.pushNamed(uri.toString());
+  } else {
+    await navigator.pushNamed(uri.toString());
+  }
+}

--- a/mobile/lib/features/debug/notifications_debug_page.dart
+++ b/mobile/lib/features/debug/notifications_debug_page.dart
@@ -1,0 +1,141 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/notifications/local_notifications.dart';
+import '../../core/notifications/notifications.dart';
+
+class NotificationsDebugPage extends ConsumerStatefulWidget {
+  const NotificationsDebugPage({super.key});
+
+  @override
+  ConsumerState<NotificationsDebugPage> createState() =>
+      _NotificationsDebugPageState();
+}
+
+class _NotificationsDebugPageState
+    extends ConsumerState<NotificationsDebugPage> {
+  late final TextEditingController _topicController;
+
+  @override
+  void initState() {
+    super.initState();
+    _topicController = TextEditingController(text: 'test');
+  }
+
+  @override
+  void dispose() {
+    _topicController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokenAsync = ref.watch(fcmTokenProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Notifications Debug'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text(
+            'FCM Token',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          tokenAsync.when(
+            data: (token) => SelectableText(token ?? 'Unavailable'),
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, _) => Text('Error: $error'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton.icon(
+            onPressed: tokenAsync.maybeWhen(
+              data: (token) => token == null
+                  ? null
+                  : () async {
+                      await Clipboard.setData(ClipboardData(text: token));
+                      if (!mounted) {
+                        return;
+                      }
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Token copied to clipboard')),
+                      );
+                    },
+              orElse: () => null,
+            ),
+            icon: const Icon(Icons.copy),
+            label: const Text('Copy token'),
+          ),
+          const Divider(height: 32),
+          TextField(
+            controller: _topicController,
+            decoration: const InputDecoration(
+              labelText: 'Course ID',
+              hintText: '123',
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: () async {
+                    final topic = _topicController.text.trim();
+                    if (topic.isEmpty) {
+                      return;
+                    }
+                    await subscribeToCourseTopic(topic);
+                    if (!mounted) {
+                      return;
+                    }
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Subscribed to course_$topic')),
+                    );
+                  },
+                  child: const Text('Subscribe'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () async {
+                    final topic = _topicController.text.trim();
+                    if (topic.isEmpty) {
+                      return;
+                    }
+                    await unsubscribeFromCourseTopic(topic);
+                    if (!mounted) {
+                      return;
+                    }
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Unsubscribed from course_$topic')),
+                    );
+                  },
+                  child: const Text('Unsubscribe'),
+                ),
+              ),
+            ],
+          ),
+          const Divider(height: 32),
+          ElevatedButton(
+            onPressed: () async {
+              final message = RemoteMessage(
+                notification: const RemoteNotification(
+                  title: 'Local test notification',
+                  body: 'Triggered from debug tools.',
+                ),
+                data: const <String, dynamic>{},
+              );
+              await showLocalNotification(message);
+            },
+            child: const Text('Send test local notification'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/home/ui/home_page.dart
+++ b/mobile/lib/features/home/ui/home_page.dart
@@ -12,11 +12,24 @@ class HomePage extends ConsumerWidget {
     final authState = ref.watch(authNotifierProvider);
     final isLoading = authState is AuthStateAuthenticating;
     final isAuthenticated = authState is AuthStateAuthenticated;
+    var showDebugTools = false;
+    assert(() {
+      showDebugTools = true;
+      return true;
+    }());
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('iroha'),
         actions: [
+          if (showDebugTools)
+            IconButton(
+              tooltip: 'Notifications debug',
+              onPressed: () {
+                Navigator.of(context).pushNamed('/debug/notifications');
+              },
+              icon: const Icon(Icons.notifications_active_outlined),
+            ),
           if (isAuthenticated)
             IconButton(
               tooltip: 'Logout',

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2,7 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
+import 'core/notifications/local_notifications.dart';
+import 'core/notifications/notifications.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await initFirebase();
+  await initializeNotificationPlugin();
+  await requestPermissions();
+  await configureHandlers();
+
   runApp(const ProviderScope(child: IrohaApp()));
 }

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -13,6 +13,9 @@ dependencies:
   flutter_riverpod: ^2.4.5
   dio: ^5.3.3
   flutter_secure_storage: ^9.0.0
+  firebase_core: ^2.25.5
+  firebase_messaging: ^14.7.10
+  flutter_local_notifications: ^16.3.2
   flutter_localizations:
     sdk: flutter
   intl: ^0.18.1


### PR DESCRIPTION
## Summary
- add Firebase Cloud Messaging and local notification initialization utilities with Riverpod providers
- introduce a notifications debug page and wire it into the app for dev builds
- document configuration steps and add Android gradle/manifest scaffolding for FCM

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d5c9bada5c832f8fffa59d2fa32a90