### PR TITLE
Add Android flavors and CI build workflow

### DIFF
--- a/.github/workflows/flutter-mobile.yml
+++ b/.github/workflows/flutter-mobile.yml
@@ -1,6 +1,7 @@
 name: Build Flutter (mobile)
 on:
-  push: { branches: [main, staging] }
+  push:
+    branches: [ main, staging ]
   workflow_dispatch:
 jobs:
   build-android:
@@ -11,7 +12,21 @@ jobs:
         with: { channel: 'stable' }
       - run: flutter pub get
         working-directory: mobile
-      - run: flutter build apk --release --dart-define=API_BASE_URL=${{ secrets.MOBILE_API_BASE_URL }} --dart-define=RETURN_URL=iroha://payment/return
+      - name: Build (staging → dev flavor)
+        if: github.ref == 'refs/heads/staging'
+        run: |
+          flutter build apk --flavor dev \
+            --dart-define=API_BASE_URL=${{ secrets.MOBILE_API_BASE_URL_STAGE }} \
+            --dart-define=RETURN_URL=iroha://payment/return
+        working-directory: mobile
+      - name: Build (main → prod flavor)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          flutter build apk --flavor prod \
+            --dart-define=API_BASE_URL=${{ secrets.MOBILE_API_BASE_URL_PROD }} \
+            --dart-define=RETURN_URL=iroha://payment/return
         working-directory: mobile
       - uses: actions/upload-artifact@v4
-        with: { name: iroha-apk, path: mobile/build/app/outputs/flutter-apk/*.apk }
+        with:
+          name: iroha-apk-${{ github.ref_name }}-${{ github.sha }}
+          path: mobile/build/app/outputs/flutter-apk/*.apk

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+mobile/android/app/google-services.json
+mobile/ios/Runner/GoogleService-Info.plist

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -26,3 +26,37 @@ The files above are ignored by git; do not commit them to the repository.
 4. Foreground messages display a local notification. Background messages are
    handled by the background message handler defined in
    `lib/core/notifications/notifications.dart`.
+
+## Flavors and environment configuration
+
+The Android app defines three flavors: `dev`, `stage`, and `prod`. The
+`google-services` Gradle plugin automatically picks the correct Firebase
+configuration for the selected flavor. Provide files with the following names
+before building if you need per-flavor Firebase projects:
+
+- `mobile/android/app/google-services.json` (prod)
+- `mobile/android/app/google-services.dev.json`
+- `mobile/android/app/google-services.stage.json`
+
+Copy the appropriate file to `mobile/android/app/google-services.json` before
+building if you keep separate Firebase projects per environment.
+
+### Running with API base URLs
+
+Provide the API base URL for each environment via `--dart-define` when running
+or building the Flutter app:
+
+- **DEV**
+  ```sh
+  flutter run --flavor dev   --dart-define=API_BASE_URL=${API_BASE_URL_DEV}   --dart-define=RETURN_URL=iroha://payment/return
+  ```
+- **STAGE**
+  ```sh
+  flutter run --flavor stage --dart-define=API_BASE_URL=${API_BASE_URL_STAGE} --dart-define=RETURN_URL=iroha://payment/return
+  ```
+- **PROD**
+  ```sh
+  flutter run --flavor prod  --dart-define=API_BASE_URL=${API_BASE_URL_PROD}  --dart-define=RETURN_URL=iroha://payment/return
+  ```
+
+Replace the environment variables with the appropriate values for your setup.

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -8,6 +8,25 @@ android {
     compileSdkVersion 34
 
     defaultConfig {
+        applicationId "com.iroha.app"
         minSdkVersion 21
+    }
+
+    flavorDimensions "env"
+    productFlavors {
+        dev {
+            dimension "env"
+            applicationIdSuffix ".dev"
+            resValue "string", "app_name", "iroha (Dev)"
+        }
+        stage {
+            dimension "env"
+            applicationIdSuffix ".stage"
+            resValue "string", "app_name", "iroha (Stage)"
+        }
+        prod {
+            dimension "env"
+            resValue "string", "app_name", "iroha"
+        }
     }
 }


### PR DESCRIPTION
## Summary
- define Android product flavors and set application IDs for dev, stage, and prod
- document flavor-specific Firebase config handling and dart-define commands
- update CI workflow to build flavor-specific APKs and upload artifacts

## Testing
- ❌ `flutter build apk --flavor dev --dart-define=API_BASE_URL=https://example.com --dart-define=RETURN_URL=iroha://payment/return` *(fails: Flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cb46da68832f8d5734d8644c0f5c