### PR TITLE
fix: update intl version and configure java 17 for android build

### DIFF
--- a/.github/workflows/flutter-mobile.yml
+++ b/.github/workflows/flutter-mobile.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - uses: subosito/flutter-action@v2
         with: { channel: 'stable' }
       - run: flutter pub get

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
   flutter: '>=3.16.0'
 
 dependencies:
@@ -18,7 +18,7 @@ dependencies:
   flutter_local_notifications: ^16.3.2
   flutter_localizations:
     sdk: flutter
-  intl: ^0.18.1
+  intl: ^0.20.2
   url_launcher: ^6.2.5
 
 


### PR DESCRIPTION
## Summary
- raise the Flutter mobile SDK constraint to Dart 3.3 and bump intl to ^0.20.2
- add Java 17 setup to the Flutter Android CI workflow for more stable Gradle builds

## Testing
- flutter --version *(fails: command not found)*
- flutter pub upgrade --major-versions *(fails: command not found)*
- flutter pub get *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cc8dc254832f8a9e571df070f739