### PR TITLE
Migrate Android host to Flutter embedding v2

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,26 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.iroha">
+    package="com.iroha.app">
 
-    <application>
+    <application
+        android:name="${applicationName}">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
+
         <service
             android:name="com.google.firebase.messaging.FirebaseMessagingService"
             android:exported="false">

--- a/mobile/android/app/src/main/kotlin/com/iroha/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/com/iroha/app/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.iroha.app
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()


### PR DESCRIPTION
## Summary
- add a Flutter v2 embedding `MainActivity` in Kotlin
- update the Android manifest for embedding v2 and align the package name with the Gradle config

## Testing
- flutter clean *(fails: `flutter` command not found in container)*
- flutter pub get *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d95f9718832fb6a47811e8e30500