### PR TITLE
Make Android CI resilient to missing Google services

### DIFF
--- a/.github/workflows/flutter-mobile.yml
+++ b/.github/workflows/flutter-mobile.yml
@@ -14,6 +14,8 @@ jobs:
           java-version: '17'
       - uses: subosito/flutter-action@v2
         with: { channel: 'stable' }
+      - run: flutter clean
+        working-directory: mobile
       - run: flutter pub get
         working-directory: mobile
       - name: Build (staging → dev flavor)

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -1,7 +1,14 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'com.google.gms.google-services'
+}
+
+def hasGoogleServices = file("google-services.json").exists()
+
+if (hasGoogleServices) {
+    apply plugin: 'com.google.gms.google-services'
+} else {
+    println("⚠️  google-services.json not found; skipping Google Services plugin for CI/local without Firebase.")
 }
 
 android {

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.1.2'
         classpath 'com.google.gms:google-services:4.4.2'
     }
 }


### PR DESCRIPTION
## Summary
- make the Google Services plugin optional based on google-services.json presence
- align the Android Gradle plugin classpath with CI usage
- ensure CI sets up Java 17 and refreshes Flutter artifacts before builds

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5dc152760832fa33542cd1c6ea0f3