### PR TITLE
Add web health route and Vercel deployment workflow

### DIFF
--- a/.github/workflows/web-vercel.yml
+++ b/.github/workflows/web-vercel.yml
@@ -1,0 +1,28 @@
+name: Deploy Web to Vercel
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: web } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'web/package-lock.json'
+      - run: npm ci
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+      - name: Pull Vercel env (prod)
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build
+        env:
+          NEXT_PUBLIC_API_BASE_URL: ${{ secrets.WEB_API_BASE_URL }}
+          NEXT_PUBLIC_RETURN_URL:   ${{ secrets.WEB_RETURN_URL }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy (prebuilt)
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_BASE_URL="https://api.example.com"
+NEXT_PUBLIC_RETURN_URL="https://iroha.example/payment/return"

--- a/web/app/_up/route.ts
+++ b/web/app/_up/route.ts
@@ -1,0 +1,11 @@
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return new Response(
+    JSON.stringify({ ok: true, t: Date.now() }),
+    {
+      headers: { 'content-type': 'application/json' },
+      status: 200,
+    },
+  );
+}

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p ${PORT:-3000}",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add a dynamic /_up health route for the Next.js app
- document required env vars via web/.env.example
- configure GitHub Actions workflow to build and deploy the web app to Vercel with monorepo-aware settings
- ensure the Next.js start script binds to the expected port for process managers

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration and requires manual selection)*

------
https://chatgpt.com/codex/tasks/task_e_68d5df00323c832fb9a59405354e3860